### PR TITLE
fix: Handle stop events properly

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -130,6 +130,7 @@ impl Engine {
         &self,
         tracks: Vec<String>,
         start_uri: Option<String>,
+        start_position_ms: u32,
         shuffle: bool,
     ) -> Result<()> {
         self.spirc.activate().ok();
@@ -142,7 +143,7 @@ impl Engine {
                 })
             }),
             playing_track: start_uri.map(PlayingTrack::Uri),
-            ..Default::default()
+            seek_to: start_position_ms,
         };
         self.spirc
             .load(LoadRequest::from_tracks(tracks, options))

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -11,7 +11,6 @@
 
 pub mod auth;
 
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -36,10 +35,25 @@ use crate::audio::{VisBands, VisualizationSink};
 pub enum EngineEvent {
     /// A new track became current — carries its Spotify URI. This is the reactive
     /// theme trigger.
-    TrackChanged { uri: String },
-    Playing { uri: String, position_ms: u32 },
-    Paused { uri: String, position_ms: u32 },
-    EndOfTrack { uri: String },
+    TrackChanged {
+        uri: String,
+    },
+    Playing {
+        uri: String,
+        position_ms: u32,
+    },
+    Paused {
+        uri: String,
+        position_ms: u32,
+    },
+    Stopped,
+    EndOfTrack {
+        uri: String,
+    },
+    PositionCorrection {
+        uri: String,
+        position_ms: u32,
+    },
 }
 
 /// A running engine: keep `spirc` alive (dropping it tears down the device), and
@@ -47,6 +61,7 @@ pub enum EngineEvent {
 pub struct Engine {
     pub spirc: Spirc,
     pub bands: Arc<Mutex<VisBands>>,
+    pub player: Arc<Player>,
     session: Session,
 }
 
@@ -68,8 +83,12 @@ impl Engine {
         self.spirc.activate().ok();
         let options = LoadRequestOptions {
             start_playing: true,
-            context_options: shuffle
-                .then(|| LoadContextOptions::Options(CtxOptions { shuffle: true, ..Default::default() })),
+            context_options: shuffle.then(|| {
+                LoadContextOptions::Options(CtxOptions {
+                    shuffle: true,
+                    ..Default::default()
+                })
+            }),
             ..Default::default()
         };
         self.spirc
@@ -90,8 +109,12 @@ impl Engine {
         let options = LoadRequestOptions {
             start_playing: true,
             seek_to: position_ms,
-            context_options: shuffle
-                .then(|| LoadContextOptions::Options(CtxOptions { shuffle: true, ..Default::default() })),
+            context_options: shuffle.then(|| {
+                LoadContextOptions::Options(CtxOptions {
+                    shuffle: true,
+                    ..Default::default()
+                })
+            }),
             playing_track: track_uri.map(PlayingTrack::Uri),
         };
         self.spirc
@@ -112,8 +135,12 @@ impl Engine {
         self.spirc.activate().ok();
         let options = LoadRequestOptions {
             start_playing: true,
-            context_options: shuffle
-                .then(|| LoadContextOptions::Options(CtxOptions { shuffle: true, ..Default::default() })),
+            context_options: shuffle.then(|| {
+                LoadContextOptions::Options(CtxOptions {
+                    shuffle: true,
+                    ..Default::default()
+                })
+            }),
             playing_track: start_uri.map(PlayingTrack::Uri),
             ..Default::default()
         };
@@ -143,6 +170,9 @@ impl Engine {
     }
     pub fn pause(&self) -> Result<()> {
         self.spirc.pause().context("pause")
+    }
+    pub fn stop(&self) {
+        self.player.stop()
     }
     pub fn toggle(&self) -> Result<()> {
         self.spirc.play_pause().context("toggle")
@@ -250,6 +280,20 @@ fn map_event(ev: player::PlayerEvent) -> Option<EngineEvent> {
             uri: track_id.to_uri().ok()?,
             position_ms,
         }),
+        P::Stopped { .. } => Some(EngineEvent::Stopped),
+        P::PositionChanged {
+            play_request_id: _,
+            track_id,
+            position_ms,
+        }
+        | P::PositionCorrection {
+            play_request_id: _,
+            track_id,
+            position_ms,
+        } => Some(EngineEvent::PositionCorrection {
+            uri: track_id.to_uri().ok()?,
+            position_ms,
+        }),
         P::EndOfTrack { track_id, .. } => Some(EngineEvent::EndOfTrack {
             uri: track_id.to_uri().ok()?,
         }),
@@ -274,7 +318,10 @@ pub async fn run(tx: flume::Sender<EngineEvent>, initial_volume_pct: u8) -> Resu
     mixer.set_volume(volume);
 
     let backend = audio_backend::find(None).expect("an audio backend should be available");
-    let player_config = PlayerConfig::default();
+    let player_config = PlayerConfig {
+        position_update_interval: Some(Duration::from_millis(100)),
+        ..Default::default()
+    };
 
     let player = {
         let bands = Arc::clone(&bands);
@@ -326,14 +373,21 @@ pub async fn run(tx: flume::Sender<EngineEvent>, initial_volume_pct: u8) -> Resu
         volume_steps: 64,
     };
 
-    let (spirc, spirc_task) = Spirc::new(connect_config, session.clone(), creds, player, mixer)
-        .await
-        .context("initialize spirc")?;
+    let (spirc, spirc_task) = Spirc::new(
+        connect_config,
+        session.clone(),
+        creds,
+        player.clone(),
+        mixer,
+    )
+    .await
+    .context("initialize spirc")?;
     tokio::spawn(spirc_task);
 
     Ok(Engine {
         spirc,
         bands,
+        player,
         session,
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1228,11 +1228,6 @@ fn handle_key(
             }
         }
         KeyCode::Media(MediaKeyCode::Stop) => {
-            // if app.playback_started {
-            //     app.seek_to(0);
-            //     let _ = app.engine.pause();
-            // }
-
             app.engine.stop();
         }
         KeyCode::Char('n') | KeyCode::Media(MediaKeyCode::TrackNext) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,7 +336,7 @@ struct TrackMeta {
 
 /// What kind of thing is currently playing — persisted so we can resume the real
 /// context (and its live queue) on reboot, not just a bare track.
-#[derive(Clone, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 enum PlaySource {
     #[default]
     None,
@@ -353,12 +353,8 @@ struct SavedState {
     shuffle: bool,
     #[serde(default)]
     repeat: bool,
-    last_uri: String,
-    last_title: String,
-    last_artist: String,
-    last_album: String,
-    last_duration_ms: u32,
-    last_position_ms: u32,
+    #[serde(default)]
+    last_played: Option<LastPlayed>,
     queue: Vec<String>,
     #[serde(default)]
     queue_uris: Vec<String>,
@@ -366,6 +362,16 @@ struct SavedState {
     source: PlaySource,
     #[serde(default)]
     source_name: String,
+}
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+struct LastPlayed {
+    uri: String,
+    title: String,
+    artist: String,
+    album: String,
+    duration_ms: u32,
+    position_ms: u32,
 }
 
 impl SavedState {
@@ -559,7 +565,7 @@ impl App {
                     self.source_name = "Liked Songs".to_string();
                     self.status = "starting Liked Songs…".to_string();
                     // Honour the current shuffle toggle instead of a dedicated row.
-                    if let Err(e) = self.engine.play_tracks(uris, None, self.shuffle) {
+                    if let Err(e) = self.engine.play_tracks(uris, None, 0, self.shuffle) {
                         self.status = format!("couldn't play: {e:#}");
                     }
                 }
@@ -615,7 +621,7 @@ impl App {
             }
             if let Err(e) = self
                 .engine
-                .play_tracks(uris, Some(item.uri.clone()), self.shuffle)
+                .play_tracks(uris, Some(item.uri.clone()), 0, self.shuffle)
             {
                 self.status = format!("couldn't play: {e:#}");
             }
@@ -664,22 +670,19 @@ async fn main() -> Result<()> {
     let picker = Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks());
 
     // Rebuild the last now-playing (paused) for a seamless resume look.
-    let now = if !saved.last_uri.is_empty() {
-        Some(NowPlaying {
-            uri: saved.last_uri.clone(),
-            title: saved.last_title.clone(),
-            artist: saved.last_artist.clone(),
-            album: saved.last_album.clone(),
-            duration_ms: saved.last_duration_ms,
-            position_ms: saved.last_position_ms,
-            position_at: Instant::now(),
-            is_playing: false,
-            cover: None,
-        })
-    } else {
-        None
-    };
-    let restore_uri = (!saved.last_uri.is_empty()).then(|| saved.last_uri.clone());
+    let now = saved.last_played.as_ref().map(|last_played| NowPlaying {
+        uri: last_played.uri.clone(),
+        title: last_played.title.clone(),
+        artist: last_played.artist.clone(),
+        album: last_played.album.clone(),
+        duration_ms: last_played.duration_ms,
+        position_ms: last_played.position_ms,
+        position_at: Instant::now(),
+        is_playing: false,
+        cover: None,
+    });
+
+    let restore_uri = saved.last_played.as_ref().map(|lp| lp.uri.clone());
 
     let app = App {
         engine,
@@ -733,6 +736,11 @@ async fn main() -> Result<()> {
     res
 }
 
+struct Radio {
+    start_position_ms: u32,
+    uris: Vec<String>,
+}
+
 async fn run_ui(
     terminal: &mut Term,
     mut app: App,
@@ -758,7 +766,7 @@ async fn run_ui(
     let (menu_tx, menu_rx) = flume::unbounded::<ActionMenu>();
     let (astatus_tx, astatus_rx) = flume::unbounded::<String>();
     let (pstate_tx, pstate_rx) = flume::unbounded::<PlaybackState>();
-    let (radio_tx, radio_rx) = flume::unbounded::<Result<Vec<String>, String>>();
+    let (radio_tx, radio_rx) = flume::unbounded::<Result<Radio, String>>();
     let (libdone_tx, libdone_rx) = flume::unbounded::<bool>();
     spawn_library_fetch(app.webapi.clone(), lib_tx.clone(), libdone_tx.clone());
 
@@ -824,8 +832,8 @@ async fn run_ui(
                 // pure recv arm starves and the station never plays.
                 while let Ok(rad) = radio_rx.try_recv() {
                     match rad {
-                        Ok(uris) if !uris.is_empty() => {
-                            if let Err(e) = app.engine.play_tracks(uris, None, false) {
+                        Ok(radio) if !radio.uris.is_empty() => {
+                            if let Err(e) = app.engine.play_tracks(radio.uris, None, radio.start_position_ms, false) {
                                 app.status = format!("couldn't play radio: {e:#}");
                             }
                             app.playback_started = true;
@@ -1074,13 +1082,14 @@ async fn run_ui(
 
 /// Resume the persisted playback source at the last track/position — the
 /// faithful reboot resume (real context ⇒ real queue continuation).
-fn resume_source(app: &mut App, radio_tx: &flume::Sender<Result<Vec<String>, String>>) {
+fn resume_source(app: &mut App, radio_tx: &flume::Sender<Result<Radio, String>>) {
     let track = app
         .now
         .as_ref()
         .map(|n| n.uri.clone())
         .filter(|u| !u.is_empty());
     let pos = app.now.as_ref().map(|n| n.position_ms).unwrap_or(0);
+
     match app.source.clone() {
         PlaySource::Context(ctx) => {
             if let Err(e) = app.engine.play_context_at(ctx, track, pos, app.shuffle) {
@@ -1101,12 +1110,16 @@ fn resume_source(app: &mut App, radio_tx: &flume::Sender<Result<Vec<String>, Str
                     Ok(r) => r.map_err(|e| e.to_string()),
                     Err(_) => Err("timed out (mercury radio endpoint unresponsive)".to_string()),
                 };
-                let _ = tx.send(res);
+
+                let _ = tx.send(res.map(|uris| Radio {
+                    uris,
+                    start_position_ms: pos,
+                }));
             });
         }
         PlaySource::Liked if !app.library.liked.is_empty() => {
             let uris: Vec<String> = app.library.liked.iter().map(|i| i.uri.clone()).collect();
-            if let Err(e) = app.engine.play_tracks(uris, track, app.shuffle) {
+            if let Err(e) = app.engine.play_tracks(uris, track, pos, app.shuffle) {
                 app.status = format!("couldn't play: {e:#}");
             }
         }
@@ -1119,7 +1132,7 @@ fn resume_source(app: &mut App, radio_tx: &flume::Sender<Result<Vec<String>, Str
                     uris.push(u.clone());
                 }
                 uris.extend(app.queue_uris.iter().cloned());
-                if let Err(e) = app.engine.play_tracks(uris, track, app.shuffle) {
+                if let Err(e) = app.engine.play_tracks(uris, track, pos, app.shuffle) {
                     app.status = format!("couldn't play: {e:#}");
                 }
             } else {
@@ -1152,7 +1165,7 @@ fn handle_key(
     detail_tx: &flume::Sender<(String, String, Vec<LibItem>)>,
     menu_tx: &flume::Sender<ActionMenu>,
     astatus_tx: &flume::Sender<String>,
-    radio_tx: &flume::Sender<Result<Vec<String>, String>>,
+    radio_tx: &flume::Sender<Result<Radio, String>>,
     libdone_tx: &flume::Sender<bool>,
 ) -> bool {
     // --- Actions menu captures input while open ---
@@ -1321,7 +1334,10 @@ fn handle_key(
                             Err("timed out (mercury radio endpoint unresponsive)".to_string())
                         }
                     };
-                    let _ = tx.send(res);
+                    let _ = tx.send(res.map(|uris| Radio {
+                        uris,
+                        start_position_ms: 0,
+                    }));
                 });
             }
             Activated::None => {}
@@ -1821,28 +1837,20 @@ fn api_contains(token: &str, url: &str) -> bool {
 
 /// Snapshot the current session to disk (volume, last track, position, queue).
 fn save_state(app: &App) {
+    let last_played = app.now.as_ref().map(|now| LastPlayed {
+        uri: now.uri.clone(),
+        title: now.title.clone(),
+        artist: now.artist.clone(),
+        album: now.album.clone(),
+        duration_ms: now.duration_ms,
+        position_ms: app.position_ms(),
+    });
+
     let s = SavedState {
         volume: app.volume,
         shuffle: app.shuffle,
         repeat: app.repeat,
-        last_uri: app.now.as_ref().map(|n| n.uri.clone()).unwrap_or_default(),
-        last_title: app
-            .now
-            .as_ref()
-            .map(|n| n.title.clone())
-            .unwrap_or_default(),
-        last_artist: app
-            .now
-            .as_ref()
-            .map(|n| n.artist.clone())
-            .unwrap_or_default(),
-        last_album: app
-            .now
-            .as_ref()
-            .map(|n| n.album.clone())
-            .unwrap_or_default(),
-        last_duration_ms: app.now.as_ref().map(|n| n.duration_ms).unwrap_or(0),
-        last_position_ms: app.position_ms(),
+        last_played,
         queue: app.queue.clone(),
         queue_uris: app.queue_uris.clone(),
         source: app.source.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,8 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use crossterm::event::{
-    self, Event, KeyCode, KeyEventKind, KeyModifiers, KeyboardEnhancementFlags, MediaKeyCode, MouseButton, MouseEventKind, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    self, Event, KeyCode, KeyEventKind, KeyModifiers, KeyboardEnhancementFlags, MediaKeyCode,
+    MouseButton, MouseEventKind, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
 use crossterm::terminal::{
@@ -1227,10 +1228,12 @@ fn handle_key(
             }
         }
         KeyCode::Media(MediaKeyCode::Stop) => {
-            if app.playback_started {
-                app.seek_to(0);
-                let _ = app.engine.pause();
-            }
+            // if app.playback_started {
+            //     app.seek_to(0);
+            //     let _ = app.engine.pause();
+            // }
+
+            app.engine.stop();
         }
         KeyCode::Char('n') | KeyCode::Media(MediaKeyCode::TrackNext) => {
             let _ = app.engine.next();
@@ -1896,6 +1899,16 @@ fn handle_engine_event(app: &mut App, ev: EngineEvent, meta_tx: &flume::Sender<T
                 n.position_at = Instant::now();
             }
         }
+        EngineEvent::Stopped => {
+            app.now = None;
+            app.playback_started = false;
+        }
+        EngineEvent::PositionCorrection { position_ms, .. } => {
+            if let Some(n) = app.now.as_mut() {
+                n.position_ms = position_ms;
+                n.position_at = Instant::now();
+            }
+        }
         EngineEvent::EndOfTrack { .. } => {}
     }
 }
@@ -1935,7 +1948,11 @@ fn apply_meta(
         duration_ms: meta.duration_ms,
         position_ms: app.now.as_ref().map(|n| n.position_ms).unwrap_or(0),
         position_at: Instant::now(),
-        is_playing: app.now.as_ref().map(|n| n.is_playing).unwrap_or(true),
+        is_playing: app
+            .now
+            .as_ref()
+            .map(|n| n.is_playing)
+            .unwrap_or(app.playback_started),
         cover,
     });
     if let Some(theme) = meta.theme {
@@ -1956,7 +1973,7 @@ fn liblog(msg: impl AsRef<str>) {
         return;
     }
     let Some(home) = myx::home_dir() else { return };
-    let dir = std::path::PathBuf::from(home).join(".cache/myx");
+    let dir = home.join(".cache/myx");
     if std::fs::create_dir_all(&dir).is_ok() {
         #[cfg(unix)]
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2996,14 +2996,12 @@ fn render_library(f: &mut Frame, app: &mut App, theme: Theme, area: Rect) {
         let total = total_items;
         let sb_x = inner.right();
         let track_h = cap;
-        let thumb_h = ((cap * cap + total - 1) / total).max(1).min(track_h);
+        let thumb_h = (cap * cap).div_ceil(total).max(1).min(track_h);
         let travel = track_h - thumb_h;
         let max_off = total - cap;
-        let thumb_y0 = if max_off == 0 {
-            0
-        } else {
-            (offset * travel + max_off / 2) / max_off
-        };
+        let thumb_y0 = (offset * travel + max_off / 2)
+            .checked_div(max_off)
+            .unwrap_or(0);
         for i in 0..track_h {
             let y = list_top + i as u16;
             if y >= inner.bottom() {


### PR DESCRIPTION
Stop was being treated like pause when it's not. This PR handles stopping properly.

Changes:

- **Added**: `EngineEvent::Stopped` and `EngineEvent::PositionCorrection` events derived from the corresponding `PlayerEvent` variants.
- **Added**: `Arc<Player>` stored in `Engine.player`.
- **Added**: `Engine::stop()` calls `Engine::player::stop()`.
- **Changed**: `MediaKeyCode::Stop` events now call `Engine::stop()` instead of faking it with `Engine::pause()` and `App::seek_to()`.
- **Changed**: `Player` is now initialized with a `PlayerConfig` that has `position_update_interval` set to 100 milliseconds. This fires `EngineEvent::PositionCorrection` events that sync positions with the player instead of only inferring them via events we know that exist.
- **Changed**: `SavedState::last_*` is now `SavedState::last_played`. Empty strings are no longer used to represent missing data, rather `LastPlayed` is wrapped in an `Option<T>`.
- **Changed**: `radio_tx/rx` is now a stream of `Radio { uris, start_position_ms }`. This allows radio saved state to resume playback from the last position instead of restarting the app. `Engine::play_tracks` is now `Engine::play_tracks(tracks, start_uri, start_position_ms, shuffle)` for that reason.
- **Fixes**: Going back without a previous track no longer corrupts the UI's state.
- **Fixes**: Stopping no longer fakes a stop instead of actually sending `PlayerEvent::Stop` to the player.
- **Fixes**: One or two clippy warnings in `main.rs`.
- **Fixes**: Stopped state not being properly saved.
- **Fixes**: Saved playback position not being restored in playback (it was in the UI).

How to reproduce the stopping issue in Myx v0.2.4:

1. Play a song from the ones in your home list.
2. Press `b` twice to go to the previous track (which does not exist).