### PR TITLE
fix: stop select loop spinning at 2.9M iterations/sec (100% CPU)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -772,7 +772,11 @@ async fn run_ui(
 
     // Reclaim server-side playback: read live state + transfer it onto myx so the
     // full context + queue + position come back.
-    spawn_restore(app.webapi.clone(), app.engine.device_id(), pstate_tx);
+    //
+    // Clone: `spawn_restore` sends once and exits. Moving the sender in would
+    // drop the last one, and a disconnected receiver resolves `recv_async()`
+    // instantly and forever — spinning the select loop below.
+    spawn_restore(app.webapi.clone(), app.engine.device_id(), pstate_tx.clone());
 
     // Re-enrich the restored last-played track (cover / theme / lyrics).
     if let Some(uri) = app.restore_uri.take() {


### PR DESCRIPTION
Fixes #13

## Problem

myx pegs ~100% of one CPU core continuously, from process start, whether or not anything is playing. I first assumed the visualiser or the album-art pipeline, but it reproduces identically in Warp and kitty, with art both working and broken, and while paused.

## Root cause

`src/main.rs` passes the `PlaybackState` sender into `spawn_restore()` **by move**:

```rust
let (pstate_tx, pstate_rx) = flume::unbounded::<PlaybackState>();
...
spawn_restore(app.webapi.clone(), app.engine.device_id(), pstate_tx);
```

`spawn_restore` sends at most once and returns, dropping the last sender. A flume receiver with no remaining senders resolves `recv_async()` **immediately** with `Err(Disconnected)` — and keeps doing so forever.

The UI loop is a `biased` `tokio::select!`, so each pass walks the arms in order, finds `pstate` permanently ready at the end, fires it, and restarts.

It also triggers earlier than you'd expect: `spawn_restore` returns early when there's no token or no active playback state, without ever sending — so a user with nothing playing hits the spin immediately at startup.

## Evidence

`sample(1)` on a debug-symbol build shows the main thread dominated by teardown of the per-iteration select futures, not by real work:

```
myx::main::{{closure}}                                        4007 samples (50%)
core::ptr::drop_in_place<(Interval::tick::{{closure}},
                          flume::async::RecvFut<...>, ...)>
  └─ <flume::async::RecvFut as Drop>::drop
       ├─ _xzm_free / _platform_memset
       ├─ VecDeque::truncate          (waiter-queue removal)
       └─ pthread_mutex_lock/unlock   (channel lock)
```

Instrumenting the loop with an iteration counter plus `is_disconnected()` on every arm:

```
LOOP 2902081/s | disconnected: ev=false in=false meta=false queue=false
                 search=false lyrics=false detail=false menu=false
                 astatus=false pstate=true
```

**2.9 million iterations/sec**, with `pstate` the only disconnected channel. Each iteration constructs and drops a `RecvFut` for all ten arms — roughly 29M future lifecycles per second, each taking the channel mutex and unregistering a waker.

## Fix

Pass a clone so the original sender stays in scope for the loop's lifetime:

```rust
spawn_restore(app.webapi.clone(), app.engine.device_id(), pstate_tx.clone());
```

## Results

| | Before | After |
|---|---|---|
| Loop iterations/sec | 2,900,000 | ~62 (the 16 ms tick) |
| CPU | ~100% of a core | ~3% |
| RSS | 28 MB | 21 MB |

Verified on macOS 15 (aarch64), measured over 40s of steady-state playback.

## No behaviour change

The arm's handler is `if let Ok(state) = ps { … }` with no `else`, so all 2.9M firings per second fell straight through — removing them removes nothing. The genuine restore message still arrives: flume drains buffered messages before reporting disconnection, so it was already delivered ahead of the `Err`s, and still is. Nothing else in the file references `pstate` beyond the channel creation and this one arm, so nothing used sender-drop as a completion signal. `cargo check --release` is clean.

## Note

The comment above the loop mentions a previous encounter with this:

> *"Recreating a `sleep()` every loop starves forever when player events are continuously ready … That was the frozen-UI bug."*

The `biased;` + persistent-interval change fixed the visible symptom (frozen UI) while the spin underneath remained — invisible, because drawing is time-gated by `last_draw.elapsed()`.

Worth noting the general invariant: **any channel used as a `select!` arm must keep a live sender for the loop's lifetime**, or that arm silently becomes a spin loop. The other nine arms happen to satisfy this because their senders stay in scope. If you'd prefer belt-and-braces, adding `, if !rx.is_disconnected()` guards to the arms would make it unable to recur — happy to include that here if you want it.
