### PR TITLE
fix: render album art in Warp (kitty unicode placeholders unsupported)

### DIFF
--- a/src/cover.rs
+++ b/src/cover.rs
@@ -8,7 +8,7 @@
 use image::DynamicImage;
 use ratatui::layout::{Rect, Size};
 use ratatui::Frame;
-use ratatui_image::picker::Picker;
+use ratatui_image::picker::{Picker, ProtocolType};
 use ratatui_image::protocol::Protocol;
 use ratatui_image::{Image, Resize};
 
@@ -23,7 +23,30 @@ impl Cover {
     /// Build a `Picker` by querying the terminal, falling back to half-blocks.
     /// Must be called after raw mode is enabled so the query can round-trip.
     pub fn make_picker() -> Picker {
-        Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks())
+        let mut picker = Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks());
+
+        // Warp advertises kitty support but lacks its unicode-placeholder
+        // placement, so kitty renders as tofu. Override *after* the query to
+        // keep the detected font size — blacklisting kitty loses it and falls
+        // back to halfblocks.
+        if picker.protocol_type() == ProtocolType::Kitty
+            && std::env::var("TERM_PROGRAM").is_ok_and(|t| t.contains("WarpTerminal"))
+        {
+            picker.set_protocol_type(ProtocolType::Iterm2);
+        }
+
+        // Escape hatch for mis-detected terminals.
+        if let Ok(want) = std::env::var("MYX_PROTOCOL") {
+            match want.to_ascii_lowercase().as_str() {
+                "kitty" => picker.set_protocol_type(ProtocolType::Kitty),
+                "iterm2" => picker.set_protocol_type(ProtocolType::Iterm2),
+                "sixel" => picker.set_protocol_type(ProtocolType::Sixel),
+                "halfblocks" => picker.set_protocol_type(ProtocolType::Halfblocks),
+                _ => {}
+            }
+        }
+
+        picker
     }
 
     /// Load a cover image from disk. Returns `None` if the file can't be decoded.

--- a/src/main.rs
+++ b/src/main.rs
@@ -667,7 +667,7 @@ async fn main() -> Result<()> {
     }
 
     let mut terminal = init_terminal()?;
-    let picker = Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks());
+    let picker = Cover::make_picker();
 
     // Rebuild the last now-playing (paused) for a seamless resume look.
     let now = saved.last_played.as_ref().map(|last_played| NowPlaying {


### PR DESCRIPTION
Fixes #14

## Problem

In [Warp](https://warp.dev), album art renders as a vertical strip of missing-glyph boxes — one column wide, as tall as the art area — instead of an image. Everything else in the UI works.

## Root cause

Warp **does** support the kitty graphics protocol, and answers the capability query affirmatively:

```
$ printf '\e_Gi=1,a=q\e\\'
^[_Gi=1;OK^[\
```

But it implements only image **transmission**, not the **unicode-placeholder placement** extension that `ratatui-image`'s kitty backend relies on (`src/protocol/kitty.rs`):

```rust
//! renders the image with the [unicode-placeholders] feature of the kitty protocol
let row_diacritics = repeat_n('\u{10EEEE}', width_usize - 1).collect();
// Draw each line of unicode placeholders but all into the first cell.
```

Warp has no glyph for `U+10EEEE`, so each row's placeholders render as tofu — and since they all go into the first cell, the result is exactly the one-column strip observed.

This is the same defect `ratatui-image` already blacklists kitty for on WezTerm and Konsole:

```rust
if is_wezterm || is_konsole {
    // "Neither implement the placeholder part of kitty correctly"
    blacklist_protocols = vec![ProtocolType::Kitty, ProtocolType::Sixel];
}
```

`ratatui-image` already knows Warp speaks iTerm2 — `WarpTerminal` is listed in `iterm2_from_env()` — but capability detection outranks that hint:

```rust
let protocol_type = capability_proto   // Some(Kitty) — Warp answers the query
    .or(tmux_proto)
    .or(iterm2_proto)                  // Some(Iterm2) — correct, but shadowed
    .unwrap_or(ProtocolType::Halfblocks);
```

Sixel isn't an option either: Warp's device-attributes reply is `\e[?62c`, with no `;4`.

## Fix

Override the protocol to iTerm2 **after** the query, when kitty was detected and we're in Warp.

The ordering is load-bearing. Blacklisting kitty up front looks tidier and was tried first — it's wrong. Warp doesn't answer `CSI 16 t`, so with the kitty response suppressed there are no useful responses left, `font_size` comes back `None`, and `from_query_stdio_with_options` falls into `DEFAULT_PICKER` — halfblocks at a fabricated 10×20 — discarding both the protocol *and* the geometry. Measured in Warp with a small probe:

```
A plain query    : protocol=Kitty        font=8x16
A + override     : protocol=Iterm2       font=8x16    <-- this PR, full resolution
B kitty blacklist: protocol=Halfblocks   font=10x20   <-- chunky, wrong aspect
```

Font size determines rendered resolution, so it has to survive the query. (Warp ignores `CSI 16 t` but does report pixel geometry via `TIOCGWINSZ` — 1094×802 px over 132×49 cells — which is where the correct 8×16 comes from.)

## Also in this PR

- **`main.rs` now calls `Cover::make_picker()`.** It was calling `Picker::from_query_stdio()` directly, duplicating the logic and bypassing `make_picker()` entirely — so any fix there would never have taken effect.
- **`MYX_PROTOCOL=kitty|iterm2|sixel|halfblocks`** escape hatch, so a mis-detected terminal can be worked around without a rebuild.

## Testing

macOS 15 (aarch64), Warp v2026.07.08. Album art renders at full resolution; reactive theming follows it correctly. No change on kitty, where detection is unaffected. `cargo check --release` clean.

## Where this probably belongs

Arguably this is a `ratatui-image` bug rather than a myx one — the crate already has the Warp iTerm2 entry and just lets the kitty capability outrank it, and the WezTerm/Konsole blacklist is the same class of problem. Happy to take it upstream instead if you'd rather not carry a terminal-specific check here; this fixes it for myx users today either way.
