### PR TITLE
perf: redraw on change, cache catalogue reads; fix album art, Connect control, idle reconnect, greyscale themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,21 +24,64 @@ they are added to, never rewritten.
   instead of 60. A held arrow key now scrolls smoothly.
 - Queue refresh and session persistence run on a timer instead of a frame
   counter — at 60fps they were firing every four seconds.
-- The visualizer's frame rate only applies while Now Playing is on screen.
+- The visualizer's frame rate only applies while Now Playing is on screen, and
+  synced lyrics animate at the same rate so the highlighted line stays on time.
+- Frames are presented atomically (synchronized output, DECSET 2026). A track
+  change recolours every glyph at once, and the terminal used to render that
+  half-applied.
+- The theme cross-fade runs 1200ms instead of 300ms. Smoothness comes from the
+  duration, not the frame rate: every present recomposes the viewport, and the
+  inline cover shimmers if that happens 60 times a second.
+- Zen mode ignores the keys that only drive the hidden library — `Tab`, `↑`/`↓`,
+  `Enter`, `/`, `o`, `r`, `P`, `S`, `Esc` — instead of moving a selection nobody
+  can see, and the footer drops their hints. `a` stays, retargeted onto the
+  playing track rather than the invisible selection.
 
 ### Fixed
 
+- A black-and-white cover no longer tints the whole UI burgundy. `rgb_to_hsl`
+  reports hue 0 for every grey, and hue 0 is red, so an achromatic dominant
+  swatch painted every surface with it. The base hue now comes from the most
+  saturated swatch in the palette, and the tint's strength scales with how
+  colourful the art actually is — greyscale art gets a neutral UI.
+- Album art is transmitted only when it changes. The escape was written into its
+  cell on every frame, so a recolour that repaints the screen dozens of times in
+  a row made the cover flicker; other frames now just hold the cells.
+- Overlays draw over the cover instead of under it, and closing one no longer
+  leaves half a popup stencilled across the art. `ratatui-image` marks the image
+  cells `Skip` without changing their symbols, and a blank cell compares equal to
+  the blank already there — so `Clear` over an image wrote nothing at all.
+  Wiping and overdrawing now use `CellDiffOption::AlwaysUpdate`.
+- Switching back to Now Playing no longer drags the previous view's text across
+  the cover.
+- myx reconnects itself after an idle spell instead of needing a restart.
+  librespot invalidates its session when the access point stops answering the
+  keep-alive and leaves recovery to the caller, so every command afterwards
+  failed with `Internal error { channel closed }`. A watchdog now rebuilds the
+  session, player and Connect device — usually before a key is pressed — and the
+  status line says so. Whatever was playing is not resumed: the replacement
+  device starts idle.
 - Album art no longer disappears after switching tmux windows. Where tmux
   reports sixel support it is drawn as sixel, unwrapped, so tmux stores the
   image itself and repaints it; kitty and iTerm2 images pass through untracked
   and are lost on the next repaint.
-- WezTerm gets iTerm2 inline images rather than kitty. It answers the kitty
-  query but has no unicode placeholders, which left a hole where the cover
-  should be.
+- The blind two-second art resend under tmux is gone. It re-encoded the cover to
+  produce an identical cell the diff discarded, so it never recovered anything;
+  `focus-events on` (see the README) and sixel do.
+- `protocol` and `MYX_PROTOCOL` are honoured inside a sixel-capable tmux. The
+  sixel picker deliberately drops tmux passthrough, so a forced kitty or iTerm2
+  used to leave its escapes for tmux to eat, and no image appeared at all.
+- kitty is detected from the client tmux has attached *now* rather than from
+  `KITTY_WINDOW_ID`, which lingers in a session's environment and made a session
+  reattached from another terminal ask for kitty images it couldn't draw.
+- The graphics query runs before the tokio runtime and the player exist. Picking
+  sixel swaps `TERM` around it, and `setenv` is only safe without concurrent
+  readers.
 - Cover requests that fail are no longer cached as image bytes, which would have
   meant a permanently broken cover — those entries never expire.
 - Cache writes go through a temporary file and a rename, so an interrupted write
-  can't leave a truncated entry behind.
+  can't leave a truncated entry behind. The temp name is unique per write, so two
+  threads fetching the same URL can't interleave into one corrupt entry.
 
 ## [0.3.0] — 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ they are added to, never rewritten.
   out, so there is a file to edit instead of a path to guess.
 - `protocol` config key (`kitty`, `iterm2`, `sixel`, `halfblocks`) for when the
   startup detection picks wrong. `MYX_PROTOCOL` still overrides it.
+- `MYX_LOG` also captures librespot's own log, which is where Spotify Connect
+  explains itself. Any value turns the log on; `debug` and `trace` widen it,
+  `warn` narrows it.
 - On-disk cache for catalogue reads and album art in `~/.cache/myx/api`. Repeat
   visits skip the network, and a stale entry is served when a request fails —
   which is what a spent API quota looks like. Entries older than 30 days are
@@ -29,7 +32,7 @@ they are added to, never rewritten.
 - Frames are presented atomically (synchronized output, DECSET 2026). A track
   change recolours every glyph at once, and the terminal used to render that
   half-applied.
-- The theme cross-fade runs 1200ms instead of 300ms. Smoothness comes from the
+- The theme cross-fade runs 1800ms instead of 300ms. Smoothness comes from the
   duration, not the frame rate: every present recomposes the viewport, and the
   inline cover shimmers if that happens 60 times a second.
 - Zen mode ignores the keys that only drive the hidden library — `Tab`, `↑`/`↓`,
@@ -82,6 +85,16 @@ they are added to, never rewritten.
 - Cache writes go through a temporary file and a rename, so an interrupted write
   can't leave a truncated entry behind. The temp name is unique per write, so two
   threads fetching the same URL can't interleave into one corrupt entry.
+- Playback controls keep working after Spotify drops myx from the Connect
+  cluster, which it does to a device left paused. librespot answers that by
+  clearing its context and discarding every later command, and the state it then
+  publishes reads as paused — so the phone greyed out its pause button and
+  neither it nor the keyboard could resume. Transport commands now reclaim the
+  active-device role first, and a forced stop routes the next play through a
+  fresh load, which is the only thing that resumes from there.
+- Position corrections are emitted once a second instead of ten times, since
+  each one pushes the whole Connect state to Spotify. Position is extrapolated
+  locally, so nothing on screen moves less smoothly.
 
 ## [0.3.0] — 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,136 @@
+# Changelog
+
+Newest first. Format follows [Keep a Changelog](https://keepachangelog.com);
+versions follow [semver](https://semver.org). Released sections are a record —
+they are added to, never rewritten.
+
+## [Unreleased]
+
+### Added
+
+- `~/.config/myx/config.toml` is written on first run with every key commented
+  out, so there is a file to edit instead of a path to guess.
+- `protocol` config key (`kitty`, `iterm2`, `sixel`, `halfblocks`) for when the
+  startup detection picks wrong. `MYX_PROTOCOL` still overrides it.
+- On-disk cache for catalogue reads and album art in `~/.cache/myx/api`. Repeat
+  visits skip the network, and a stale entry is served when a request fails —
+  which is what a spent API quota looks like. Entries older than 30 days are
+  swept once per run.
+
+### Changed
+
+- Redraws are driven by changes rather than a fixed rate: input redraws within
+  one terminal refresh, animation runs at 30fps, an untouched screen at 2fps
+  instead of 60. A held arrow key now scrolls smoothly.
+- Queue refresh and session persistence run on a timer instead of a frame
+  counter — at 60fps they were firing every four seconds.
+- The visualizer's frame rate only applies while Now Playing is on screen.
+
+### Fixed
+
+- Album art no longer disappears after switching tmux windows. Where tmux
+  reports sixel support it is drawn as sixel, unwrapped, so tmux stores the
+  image itself and repaints it; kitty and iTerm2 images pass through untracked
+  and are lost on the next repaint.
+- WezTerm gets iTerm2 inline images rather than kitty. It answers the kitty
+  query but has no unicode placeholders, which left a hole where the cover
+  should be.
+- Cover requests that fail are no longer cached as image bytes, which would have
+  meant a permanently broken cover — those entries never expire.
+- Cache writes go through a temporary file and a rename, so an interrupted write
+  can't leave a truncated entry behind.
+
+## [0.3.0] — 2026-07-28
+
+### Added
+
+- Native media controls (macOS, Windows, Linux) via souvlaki, with a winit event
+  loop on macOS.
+- CI: fmt, clippy and tests on push and pull request, once per change.
+
+### Fixed
+
+- Migrated to the February 2026 Web API: liking a track, artist pages, adding to
+  a playlist and the Home feed all called endpoints that had been removed.
+- Web API recovery completes before the TUI starts, so a re-authorization prompt
+  can't be hidden by the alternate screen.
+- Hour-long `429` backoffs are no longer waited out; a drill-in fails fast
+  instead of appearing to hang.
+- Native controls lifecycle hardened.
+- Seeking updated for the changed librespot API.
+
+## [0.2.5] — 2026-07-26
+
+### Added
+
+- `P` / `S` play the highlighted playlist directly.
+- Scroll wheel adjusts volume — local mixer immediately, Spotify in the
+  background.
+
+### Fixed
+
+- Album art transitions keep the old cover until the new one loads, and a
+  dropped image is retransmitted rather than leaving the previous track's art.
+- Album art renders in Warp, which does not support kitty placeholders.
+- Select loop no longer spins at 2.9M iterations/sec.
+- Saved state restores when the last session was stopped.
+- Graceful fallback when the terminal has no keyboard-enhancement support.
+- Playlist track listing.
+
+### Changed
+
+- Enter is labelled "select", space shows play or pause depending on state.
+
+## [0.2.3] — 2026-07-24
+
+### Added
+
+- Media keys.
+
+### Fixed
+
+- Full Windows support: cross-platform `home_dir()` in place of raw `HOME`
+  lookups, unix permissions guarded by `#[cfg(unix)]`.
+- Action failures surface the real error instead of "action failed".
+
+## [0.2.0] — 2026-07-23
+
+### Added
+
+- UX overhaul and mouse support.
+
+### Fixed
+
+- Post-audit hardening.
+
+## [0.1.3] — 2026-07-23
+
+### Added
+
+- Seek with shift+arrows or a click on the progress bar.
+- Sort lists with `o` (added / title / artist).
+- Queue persists track URIs, so resume continues past the first song.
+- Homebrew, AUR, `.deb` and crates.io publishing; cargo-dist release pipeline
+  with prebuilt binaries.
+
+### Changed
+
+- Adaptive framerate; tokio workers capped at 4.
+- Library sections reordered (Home / Liked / Playlists / Albums / Artists /
+  Recent), with Shuffle and Play rows on Liked.
+- Fat-LTO release profile.
+
+### Fixed
+
+- Frozen UI, single-instance safety, resilient library loading.
+- `vergen` pinned so a fresh `cargo install` resolves librespot-core.
+
+### Security
+
+- Bundled client id removed — `MYX_CLIENT_ID` or `~/.config/myx/client_id` is
+  now required.
+
+## [0.1.0] — 2026-07-22
+
+First release: terminal Spotify player with reactive theming, an FFT
+visualizer, synced lyrics, library, search, radio and context resume.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,6 +2808,7 @@ dependencies = [
  "librespot-connect",
  "librespot-core",
  "librespot-playback",
+ "log",
  "open",
  "rand 0.9.5",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ open = { version = "5", optional = true }
 fs2 = { version = "0.4", optional = true }
 souvlaki = { version = "0.8.3", default-features = false, features = ["pollster", "zbus", "zvariant"] }
 toml = { version = "1", default-features = false, features = ["parse", "serde"], optional = true }
+log = { version = "0.4.33", features = ["std"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-win = "3.0.0"

--- a/README.md
+++ b/README.md
@@ -80,13 +80,14 @@ Holding `⇧ ←` / `⇧ →` scrubs continuously and commits one seek when you 
 `⇧ ⏎` needs a terminal that reports modified Enter (kitty, WezTerm, foot); `P`
 does the same everywhere.
 
-Inside tmux, add `set -g focus-events on` to `~/.tmux.conf` so album art is
-re-sent the moment you switch back to myx's window.
+The album-art protocol is detected at startup and picked per terminal, including
+inside tmux. If your tmux has no sixel support, add `set -g focus-events on` to
+`~/.tmux.conf` so the art is re-sent when you switch back to myx's window.
 
 ## Config
 
-Optional, at `~/.config/myx/config.toml`. Every key has a default, so you only
-write the ones you want to change:
+`~/.config/myx/config.toml` is written on first run with every key commented
+out, so there is a file to edit and nothing to look up:
 
 ```toml
 # Rows kept visible above and below the cursor before the list scrolls.
@@ -94,6 +95,11 @@ scrolloff = 3
 
 # Spotify app client id. MYX_CLIENT_ID overrides this if it is set.
 client_id = "your-client-id"
+
+# kitty, iterm2, sixel or halfblocks. Leave it out to auto-detect; set it if
+# album art comes out as a coarse mosaic, which means the terminal never
+# answered the detection query. MYX_PROTOCOL overrides this.
+protocol = "kitty"
 ```
 
 ## Credits

--- a/examples/probe.rs
+++ b/examples/probe.rs
@@ -52,6 +52,8 @@ async fn main() -> anyhow::Result<()> {
                     EngineEvent::Paused { uri, position_ms } => println!("⏸ paused    {uri} @ {position_ms}ms"),
                     EngineEvent::EndOfTrack { uri } => println!("⏹ end       {uri}"),
                     EngineEvent::Stopped => println!("⏹ stopped"),
+                    EngineEvent::Reconnecting => println!("⟳ access point lost, reconnecting"),
+                    EngineEvent::Reconnected => println!("⟳ reconnected"),
                     EngineEvent::PositionCorrection { uri, position_ms } => {
                         println!("↔ position  {uri} @ {position_ms}ms")
                     }

--- a/examples/theme_demo.rs
+++ b/examples/theme_demo.rs
@@ -52,7 +52,7 @@ fn main() -> io::Result<()> {
     let mut terminal = init()?;
 
     // Build the image picker *after* raw mode so the terminal query round-trips.
-    let picker = Cover::make_picker();
+    let picker = Cover::make_picker(None);
 
     // Load the cover once, derive a reactive theme from the same pixels, then hand
     // the decoded image to the Cover renderer.

--- a/src/color.rs
+++ b/src/color.rs
@@ -84,11 +84,22 @@ pub fn vibrance(c: Rgb) -> f32 {
     h.s * l_penalty.max(0.0)
 }
 
+/// Below this saturation a colour has no meaningful hue: `rgb_to_hsl` reports 0
+/// for every grey, and 0 is red.
+pub const ACHROMATIC: f32 = 0.12;
+
 /// Clamp a color into a range that reads cleanly as a foreground on a dark
 /// surface: bright enough to pop, saturated enough to feel intentional.
 pub fn for_dark_fg(c: Rgb) -> Rgb {
     let h = rgb_to_hsl(c);
-    hsl_to_rgb(Hsl::new(h.h, h.s.clamp(0.45, 0.95), h.l.clamp(0.58, 0.76)))
+    // Raising the floor on a grey would invent a hue it never had, turning a
+    // black-and-white cover into a red one.
+    let s = if h.s < ACHROMATIC {
+        h.s
+    } else {
+        h.s.clamp(0.45, 0.95)
+    };
+    hsl_to_rgb(Hsl::new(h.h, s, h.l.clamp(0.58, 0.76)))
 }
 
 /// Build a color from a base hue with explicit saturation & lightness. The

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@
 //! all fall back to defaults — a typo must never lock someone out of the app.
 
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 #[derive(Deserialize)]
@@ -12,6 +12,10 @@ pub struct Config {
     pub scrolloff: usize,
     /// Spotify app client id. `MYX_CLIENT_ID` takes precedence.
     pub client_id: Option<String>,
+    /// Terminal graphics protocol: kitty, iterm2, sixel or halfblocks. Set this
+    /// when the startup query misfires and the art comes out as a mosaic.
+    /// `MYX_PROTOCOL` takes precedence.
+    pub protocol: Option<String>,
 }
 
 impl Default for Config {
@@ -19,6 +23,7 @@ impl Default for Config {
         Self {
             scrolloff: 3,
             client_id: None,
+            protocol: None,
         }
     }
 }
@@ -30,14 +35,37 @@ pub fn get() -> &'static Config {
     CONFIG.get_or_init(Config::load)
 }
 
+/// Written on first run so there is a file to edit instead of a path to guess.
+/// Every key is commented out, so it parses to exactly the defaults.
+const TEMPLATE: &str = "\
+# myx settings. Every key is optional — uncomment one to change it.
+
+# Rows kept visible above and below the list cursor, like vim's scrolloff.
+#scrolloff = 3
+
+# Spotify app client id. MYX_CLIENT_ID overrides this if it is set.
+#client_id = \"\"
+
+# Terminal graphics protocol: kitty, iterm2, sixel or halfblocks.
+# Leave it commented to auto-detect; set it if album art comes out as a coarse
+# mosaic, which means the detection query went unanswered.
+#protocol = \"kitty\"
+";
+
 impl Config {
     pub fn path() -> Option<PathBuf> {
         Some(crate::home_dir()?.join(".config/myx/config.toml"))
     }
 
     fn load() -> Self {
-        Self::path()
-            .and_then(|p| std::fs::read_to_string(p).ok())
+        let Some(path) = Self::path() else {
+            return Self::default();
+        };
+        if !path.exists() {
+            write_template(&path);
+        }
+        std::fs::read_to_string(&path)
+            .ok()
             .and_then(|s| Self::parse(&s))
             .unwrap_or_default()
     }
@@ -45,6 +73,14 @@ impl Config {
     fn parse(s: &str) -> Option<Self> {
         toml::from_str(s).ok()
     }
+}
+
+/// Best effort: a read-only home just means no file, never a failed start.
+fn write_template(path: &Path) {
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    let _ = std::fs::write(path, TEMPLATE);
 }
 
 #[cfg(test)]
@@ -75,5 +111,36 @@ mod tests {
     #[test]
     fn malformed_config_falls_back_rather_than_failing() {
         assert!(Config::parse("scrolloff = \"three\"").is_none());
+    }
+
+    #[test]
+    fn the_first_run_template_parses_to_the_defaults() {
+        // Everything in it is commented out, so writing it can never change how
+        // myx behaves — it only shows what there is to change.
+        let c = Config::parse(TEMPLATE).expect("template is valid toml");
+        let d = Config::default();
+        assert_eq!(c.scrolloff, d.scrolloff);
+        assert!(c.client_id.is_none());
+        assert!(c.protocol.is_none());
+    }
+
+    #[test]
+    fn the_template_is_written_once_and_never_over_an_existing_file() {
+        let dir = std::env::temp_dir().join("myx-config-template");
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = dir.join("config.toml");
+
+        write_template(&path);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), TEMPLATE);
+
+        std::fs::write(&path, "scrolloff = 9").unwrap();
+        // `load` only writes when the file is missing; the edit has to survive.
+        assert!(path.exists());
+        assert_eq!(
+            Config::parse(&std::fs::read_to_string(&path).unwrap())
+                .unwrap()
+                .scrolloff,
+            9
+        );
     }
 }

--- a/src/cover.rs
+++ b/src/cover.rs
@@ -11,6 +11,7 @@ use ratatui::Frame;
 use ratatui_image::picker::{Picker, ProtocolType};
 use ratatui_image::protocol::Protocol;
 use ratatui_image::{Image, Resize};
+use std::sync::OnceLock;
 
 pub struct Cover {
     img: DynamicImage,
@@ -21,48 +22,52 @@ pub struct Cover {
 
 impl Cover {
     /// Build a `Picker` by querying the terminal, falling back to half-blocks.
-    /// Must be called after raw mode is enabled so the query can round-trip.
+    ///
+    /// Must be called after raw mode is enabled so the query can round-trip, and
+    /// before any thread is spawned — see [`untmuxed_sixel_picker`].
     pub fn make_picker(preferred: Option<&str>) -> Picker {
         let mut picker = Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks());
 
-        // Warp and WezTerm answer the kitty query but neither places unicode
-        // placeholders, which is how `ratatui-image` draws kitty — the cells
-        // come out empty and the cover is a see-through hole. Both draw iTerm2
-        // inline images.
-        let no_placeholders = std::env::var_os("WEZTERM_EXECUTABLE").is_some()
-            || std::env::var("TERM_PROGRAM").is_ok_and(|t| t.contains("WarpTerminal"));
+        // An explicit choice beats every heuristic below — that is the whole
+        // point of the escape hatch.
+        let forced = std::env::var("MYX_PROTOCOL")
+            .ok()
+            .or_else(|| preferred.map(String::from))
+            .and_then(|want| parse_protocol(&want));
 
-        if tmux_stores_sixel() {
-            // The cover has to survive a window switch, and sixel is the only
-            // protocol tmux stores in its own pane buffer and repaints itself.
-            // Everything else rides through as passthrough, untracked, and is
-            // gone the moment tmux repaints the pane from that buffer.
-            picker = untmuxed_sixel_picker(picker.font_size());
-        } else if no_placeholders {
-            // Overridden *after* the query so the detected font size survives:
-            // blacklisting kitty up front loses it and falls back to halfblocks.
+        // The cover has to survive a window switch, and sixel is the only
+        // protocol tmux stores in its own pane buffer and repaints itself.
+        // Everything else rides through as passthrough, untracked, and is gone
+        // the moment tmux repaints the pane from that buffer.
+        //
+        // Sending it *unwrapped* is what makes tmux store it, which also strips
+        // the passthrough every other protocol needs — so a forced kitty or
+        // iTerm2 must never come out of this branch, or its escapes reach tmux
+        // bare and get eaten.
+        if forced.is_none_or(|p| p == ProtocolType::Sixel) && tmux_stores_sixel() {
+            return untmuxed_sixel_picker(picker.font_size());
+        }
+
+        if let Some(proto) = forced {
+            // Set *after* the query so the detected font size survives:
+            // blacklisting a protocol up front loses it and falls back to
+            // halfblocks.
+            picker.set_protocol_type(proto);
+            return picker;
+        }
+
+        if std::env::var("TERM_PROGRAM").is_ok_and(|t| t.contains("WarpTerminal")) {
+            // Warp answers the kitty query but does not place unicode
+            // placeholders, which is how `ratatui-image` draws kitty — the cells
+            // come out empty and the cover is a see-through hole. WezTerm has
+            // the same gap and needs no help here: `ratatui-image` blacklists
+            // kitty for it already.
             picker.set_protocol_type(ProtocolType::Iterm2);
-        } else if picker.protocol_type() == ProtocolType::Halfblocks
-            && std::env::var_os("KITTY_WINDOW_ID").is_some()
-        {
+        } else if picker.protocol_type() == ProtocolType::Halfblocks && outer_terminal_is_kitty() {
             // Inside tmux the graphics query goes unanswered even when the outer
             // terminal draws images — the cell-size reply still arrives, so it
             // looks like a legitimate halfblocks terminal.
             picker.set_protocol_type(ProtocolType::Kitty);
-        }
-
-        // Escape hatch for mis-detected terminals.
-        if let Some(want) = std::env::var("MYX_PROTOCOL")
-            .ok()
-            .or_else(|| preferred.map(String::from))
-        {
-            match want.to_ascii_lowercase().as_str() {
-                "kitty" => picker.set_protocol_type(ProtocolType::Kitty),
-                "iterm2" => picker.set_protocol_type(ProtocolType::Iterm2),
-                "sixel" => picker.set_protocol_type(ProtocolType::Sixel),
-                "halfblocks" => picker.set_protocol_type(ProtocolType::Halfblocks),
-                _ => {}
-            }
         }
 
         picker
@@ -89,6 +94,15 @@ impl Cover {
     /// sees a fresh cell, forcing retransmission.
     pub fn invalidate_cache(&mut self) {
         self.cached = None;
+    }
+
+    /// Whether drawing into `area` would have to re-encode, meaning the image
+    /// must go to the terminal again.
+    pub fn needs_send(&self, area: Rect) -> bool {
+        self.cached
+            .as_ref()
+            .map(|(cached_area, _)| *cached_area != area)
+            .unwrap_or(true)
     }
 
     pub fn render(&mut self, frame: &mut Frame, area: Rect) {
@@ -118,17 +132,61 @@ impl Cover {
     }
 }
 
+/// The requested protocol, or `None` for anything unrecognised — a typo must
+/// fall back to detection rather than to a protocol the terminal can't draw.
+fn parse_protocol(want: &str) -> Option<ProtocolType> {
+    match want.to_ascii_lowercase().as_str() {
+        "kitty" => Some(ProtocolType::Kitty),
+        "iterm2" => Some(ProtocolType::Iterm2),
+        "sixel" => Some(ProtocolType::Sixel),
+        "halfblocks" => Some(ProtocolType::Halfblocks),
+        _ => None,
+    }
+}
+
+/// What tmux says about the client attached *right now*, as
+/// `<termfeatures>|<termname>`. Empty outside tmux.
+fn tmux_client_info() -> &'static str {
+    static INFO: OnceLock<String> = OnceLock::new();
+    INFO.get_or_init(|| {
+        if std::env::var_os("TMUX").is_none() {
+            return String::new();
+        }
+        std::process::Command::new("tmux")
+            .args(["display", "-p", "#{client_termfeatures}|#{client_termname}"])
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+            .unwrap_or_default()
+    })
+}
+
+/// Split a `tmux display` reply into the two things we ask it about: whether the
+/// client can store sixel, and whether it is kitty.
+fn parse_client_info(raw: &str) -> (bool, bool) {
+    match raw.split_once('|') {
+        Some((features, term)) => (features.contains("sixel"), term.contains("kitty")),
+        None => (false, false),
+    }
+}
+
 /// Whether this tmux both runs us and can store sixel images itself. tmux only
 /// reports `sixel` in its terminal features when it was built with sixel
 /// support and the outer terminal advertises it.
 fn tmux_stores_sixel() -> bool {
-    if std::env::var_os("TMUX").is_none() {
-        return false;
+    parse_client_info(tmux_client_info()).0
+}
+
+/// Whether the terminal actually drawing our output is kitty.
+///
+/// Inside tmux this has to come from tmux: `KITTY_WINDOW_ID` records whichever
+/// terminal *created* the session and stays in its environment forever, so a
+/// session reattached from somewhere else would still claim to be kitty and get
+/// kitty escapes it can't draw.
+fn outer_terminal_is_kitty() -> bool {
+    if std::env::var_os("TMUX").is_some() {
+        return parse_client_info(tmux_client_info()).1;
     }
-    std::process::Command::new("tmux")
-        .args(["display", "-p", "#{client_termfeatures}"])
-        .output()
-        .is_ok_and(|o| String::from_utf8_lossy(&o.stdout).contains("sixel"))
+    std::env::var_os("KITTY_WINDOW_ID").is_some()
 }
 
 /// A sixel picker that does *not* wrap its escapes in tmux passthrough.
@@ -137,9 +195,17 @@ fn tmux_stores_sixel() -> bool {
 /// which is exactly what stops tmux from parsing the image and keeping it. The
 /// markers are hidden only for the moment the picker reads them.
 ///
-/// ponytail: `set_var` is process-wide, so this races anything else reading
-/// `TERM` — nothing does, and it runs once during startup. The clean fix is a
-/// `ratatui-image` API for opting out of the tmux wrapper.
+/// # Safety
+///
+/// `set_var` mutates the process-wide environment block, which can reallocate it
+/// under a concurrent `getenv` of *any* variable. [`Cover::make_picker`] is
+/// therefore called from `main` before the tokio runtime and the player engine
+/// exist. The only thread that can still overlap is the one `ratatui-image`
+/// spawns for its terminal query, and by the time the query's result reaches us
+/// that thread is restoring the terminal mode — past its last environment read.
+///
+/// ponytail: the clean fix is a `ratatui-image` API for opting out of the tmux
+/// wrapper; until then, the call-site ordering is the guarantee.
 fn untmuxed_sixel_picker(font_size: ratatui_image::FontSize) -> Picker {
     let saved = [
         ("TERM", std::env::var("TERM").ok()),
@@ -168,6 +234,30 @@ mod tests {
     use super::*;
     use ratatui::layout::Rect;
     use std::time::Instant;
+
+    #[test]
+    fn a_protocol_name_maps_to_its_protocol_and_a_typo_to_detection() {
+        assert_eq!(parse_protocol("Sixel"), Some(ProtocolType::Sixel));
+        assert_eq!(parse_protocol("kitty"), Some(ProtocolType::Kitty));
+        assert_eq!(parse_protocol("iterm2"), Some(ProtocolType::Iterm2));
+        assert_eq!(parse_protocol("halfblocks"), Some(ProtocolType::Halfblocks));
+        assert_eq!(parse_protocol("kity"), None);
+    }
+
+    #[test]
+    fn tmux_reports_what_the_attached_client_can_do() {
+        let (sixel, kitty) = parse_client_info("256,RGB,sixel,title|xterm-256color\n");
+        assert!(sixel);
+        assert!(!kitty);
+
+        let (sixel, kitty) = parse_client_info("256,RGB,title|xterm-kitty\n");
+        assert!(!sixel);
+        assert!(kitty);
+
+        // Outside tmux there is no reply at all, and nothing may be inferred:
+        // guessing kitty here would send escapes a plain terminal prints raw.
+        assert_eq!(parse_client_info(""), (false, false));
+    }
 
     /// What one cover re-encode costs on the UI thread, per protocol. Ignored
     /// because it measures rather than asserts:

--- a/src/cover.rs
+++ b/src/cover.rs
@@ -22,21 +22,40 @@ pub struct Cover {
 impl Cover {
     /// Build a `Picker` by querying the terminal, falling back to half-blocks.
     /// Must be called after raw mode is enabled so the query can round-trip.
-    pub fn make_picker() -> Picker {
+    pub fn make_picker(preferred: Option<&str>) -> Picker {
         let mut picker = Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks());
 
-        // Warp advertises kitty support but lacks its unicode-placeholder
-        // placement, so kitty renders as tofu. Override *after* the query to
-        // keep the detected font size — blacklisting kitty loses it and falls
-        // back to halfblocks.
-        if picker.protocol_type() == ProtocolType::Kitty
-            && std::env::var("TERM_PROGRAM").is_ok_and(|t| t.contains("WarpTerminal"))
-        {
+        // Warp and WezTerm answer the kitty query but neither places unicode
+        // placeholders, which is how `ratatui-image` draws kitty — the cells
+        // come out empty and the cover is a see-through hole. Both draw iTerm2
+        // inline images.
+        let no_placeholders = std::env::var_os("WEZTERM_EXECUTABLE").is_some()
+            || std::env::var("TERM_PROGRAM").is_ok_and(|t| t.contains("WarpTerminal"));
+
+        if tmux_stores_sixel() {
+            // The cover has to survive a window switch, and sixel is the only
+            // protocol tmux stores in its own pane buffer and repaints itself.
+            // Everything else rides through as passthrough, untracked, and is
+            // gone the moment tmux repaints the pane from that buffer.
+            picker = untmuxed_sixel_picker(picker.font_size());
+        } else if no_placeholders {
+            // Overridden *after* the query so the detected font size survives:
+            // blacklisting kitty up front loses it and falls back to halfblocks.
             picker.set_protocol_type(ProtocolType::Iterm2);
+        } else if picker.protocol_type() == ProtocolType::Halfblocks
+            && std::env::var_os("KITTY_WINDOW_ID").is_some()
+        {
+            // Inside tmux the graphics query goes unanswered even when the outer
+            // terminal draws images — the cell-size reply still arrives, so it
+            // looks like a legitimate halfblocks terminal.
+            picker.set_protocol_type(ProtocolType::Kitty);
         }
 
         // Escape hatch for mis-detected terminals.
-        if let Ok(want) = std::env::var("MYX_PROTOCOL") {
+        if let Some(want) = std::env::var("MYX_PROTOCOL")
+            .ok()
+            .or_else(|| preferred.map(String::from))
+        {
             match want.to_ascii_lowercase().as_str() {
                 "kitty" => picker.set_protocol_type(ProtocolType::Kitty),
                 "iterm2" => picker.set_protocol_type(ProtocolType::Iterm2),
@@ -95,6 +114,94 @@ impl Cover {
 
         if let Some((_, protocol)) = &self.cached {
             frame.render_widget(Image::new(protocol), area);
+        }
+    }
+}
+
+/// Whether this tmux both runs us and can store sixel images itself. tmux only
+/// reports `sixel` in its terminal features when it was built with sixel
+/// support and the outer terminal advertises it.
+fn tmux_stores_sixel() -> bool {
+    if std::env::var_os("TMUX").is_none() {
+        return false;
+    }
+    std::process::Command::new("tmux")
+        .args(["display", "-p", "#{client_termfeatures}"])
+        .output()
+        .is_ok_and(|o| String::from_utf8_lossy(&o.stdout).contains("sixel"))
+}
+
+/// A sixel picker that does *not* wrap its escapes in tmux passthrough.
+///
+/// `ratatui-image` adds that wrapper whenever the environment looks like tmux,
+/// which is exactly what stops tmux from parsing the image and keeping it. The
+/// markers are hidden only for the moment the picker reads them.
+///
+/// ponytail: `set_var` is process-wide, so this races anything else reading
+/// `TERM` — nothing does, and it runs once during startup. The clean fix is a
+/// `ratatui-image` API for opting out of the tmux wrapper.
+fn untmuxed_sixel_picker(font_size: ratatui_image::FontSize) -> Picker {
+    let saved = [
+        ("TERM", std::env::var("TERM").ok()),
+        ("TERM_PROGRAM", std::env::var("TERM_PROGRAM").ok()),
+    ];
+    unsafe {
+        std::env::set_var("TERM", "xterm-256color");
+        std::env::remove_var("TERM_PROGRAM");
+    }
+    #[allow(deprecated)]
+    let mut picker = Picker::from_fontsize(font_size);
+    for (key, value) in saved {
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+    picker.set_protocol_type(ProtocolType::Sixel);
+    picker
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::layout::Rect;
+    use std::time::Instant;
+
+    /// What one cover re-encode costs on the UI thread, per protocol. Ignored
+    /// because it measures rather than asserts:
+    ///   cargo test --lib -- --ignored --nocapture encode_cost
+    #[test]
+    #[ignore]
+    fn encode_cost() {
+        let mut img = image::RgbImage::new(640, 640);
+        for (x, y, p) in img.enumerate_pixels_mut() {
+            *p = image::Rgb([(x % 256) as u8, (y % 256) as u8, ((x + y) % 256) as u8]);
+        }
+        let img = DynamicImage::ImageRgb8(img);
+        let area = Rect::new(0, 0, 30, 15);
+
+        for proto in [
+            ProtocolType::Halfblocks,
+            ProtocolType::Kitty,
+            ProtocolType::Iterm2,
+            ProtocolType::Sixel,
+        ] {
+            let mut picker = Picker::halfblocks();
+            picker.set_protocol_type(proto);
+            let mut cover = Cover::from_image(img.clone(), picker);
+            let runs = 20;
+            let t = Instant::now();
+            for _ in 0..runs {
+                cover.invalidate_cache();
+                let _ = cover.picker.new_protocol(
+                    cover.img.clone(),
+                    Size::new(area.width, area.height),
+                    Resize::Fit(None),
+                );
+            }
+            println!("{proto:?}: {:?} per encode", t.elapsed() / runs);
         }
     }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -11,7 +11,7 @@
 
 pub mod auth;
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -48,6 +48,11 @@ pub enum EngineEvent {
         position_ms: u32,
     },
     Stopped,
+    /// The access point went away and a replacement connection is being built.
+    Reconnecting,
+    /// Playback control works again. Whatever was playing is not resumed — the
+    /// new Connect device starts idle.
+    Reconnected,
     EndOfTrack {
         uri: String,
     },
@@ -57,21 +62,68 @@ pub enum EngineEvent {
     },
 }
 
-/// A running engine: keep `spirc` alive (dropping it tears down the device), and
-/// read `bands` for the live visualizer.
-pub struct Engine {
-    pub spirc: Spirc,
-    pub bands: Arc<Mutex<VisBands>>,
-    pub player: Arc<Player>,
-    pub mixer: Arc<SoftMixer>,
+/// Everything that dies with the access-point connection.
+///
+/// librespot invalidates the session when its keep-alive ping goes unanswered
+/// and documents that one "cannot yet be reused once invalidated", so coming
+/// back from an idle spell means building a fresh set of these rather than
+/// repairing the old ones.
+struct Link {
+    spirc: Spirc,
+    player: Arc<Player>,
     session: Session,
+}
+
+/// A running engine: keep it alive (dropping it tears down the Connect device),
+/// and read `bands` for the live visualizer.
+pub struct Engine {
+    pub bands: Arc<Mutex<VisBands>>,
+    inner: Arc<Inner>,
+}
+
+/// The half of the engine the reconnect watchdog needs to hold, so it can swap
+/// the connection out from under the `Engine` the UI is using.
+struct Inner {
+    link: Mutex<Arc<Link>>,
+    mixer: Arc<SoftMixer>,
+    bands: Arc<Mutex<VisBands>>,
+    events: flume::Sender<EngineEvent>,
+    /// First-login credentials, used only until librespot has cached reusable
+    /// ones: a first run authenticates with a one-shot OAuth token that a
+    /// relogin hours later would be refused.
+    creds: Credentials,
+}
+
+impl Inner {
+    fn link(&self) -> Arc<Link> {
+        Arc::clone(&self.link.lock().unwrap_or_else(PoisonError::into_inner))
+    }
+
+    /// Whether the access point has gone away and every command would now fail
+    /// with a closed channel.
+    fn is_stale(&self) -> bool {
+        self.link().session.is_invalid()
+    }
+
+    /// Build a replacement connection and swap it in. The dead one is dropped
+    /// afterwards, which stops its player and ends its event bridge.
+    async fn reconnect(&self) -> Result<()> {
+        let fresh = Arc::new(connect(&self.creds, &self.mixer, &self.bands, &self.events).await?);
+        let dead = std::mem::replace(
+            &mut *self.link.lock().unwrap_or_else(PoisonError::into_inner),
+            fresh,
+        );
+        drop(dead);
+        Ok(())
+    }
 }
 
 impl Engine {
     /// Fetch a fresh Web API access token off the librespot session (login5).
     /// Used for track metadata + cover art lookups.
     pub async fn web_token(&self) -> Result<String> {
-        let fut = self.session.login5().auth_token();
+        let session = self.inner.link().session.clone();
+        let fut = session.login5().auth_token();
         let token = tokio::time::timeout(Duration::from_secs(5), fut)
             .await
             .map_err(|_| anyhow!("timed out fetching web token"))?
@@ -79,24 +131,36 @@ impl Engine {
         Ok(token.access_token)
     }
 
+    /// Run a Spirc command, translating the failure that follows a dropped
+    /// access point into something the status line can explain. The watchdog is
+    /// already building a replacement; the key just has to be pressed again.
+    fn command<T>(
+        &self,
+        what: &'static str,
+        f: impl FnOnce(&Spirc) -> Result<T, librespot_core::Error>,
+    ) -> Result<T> {
+        let link = self.inner.link();
+        f(&link.spirc).map_err(|e| {
+            if link.session.is_invalid() {
+                anyhow!("connection dropped — reconnecting, try again in a moment")
+            } else {
+                anyhow!("{what}: {e}")
+            }
+        })
+    }
+
     /// Start playing a context (playlist / album / artist / track URI). When
     /// `shuffle` is set, Spotify shuffles the *entire* context server-side.
     pub fn play_context(&self, context_uri: impl Into<String>, shuffle: bool) -> Result<()> {
-        self.spirc.activate().ok();
         let options = LoadRequestOptions {
             start_playing: true,
-            context_options: shuffle.then(|| {
-                LoadContextOptions::Options(CtxOptions {
-                    shuffle: true,
-                    ..Default::default()
-                })
-            }),
+            context_options: context_options(shuffle),
             ..Default::default()
         };
-        self.spirc
-            .load(LoadRequest::from_context_uri(context_uri.into(), options))
-            .context("load context")?;
-        Ok(())
+        self.command("load context", |spirc| {
+            spirc.activate().ok();
+            spirc.load(LoadRequest::from_context_uri(context_uri.into(), options))
+        })
     }
 
     /// Load a context and start at a specific track + position (context resume).
@@ -107,22 +171,16 @@ impl Engine {
         position_ms: u32,
         shuffle: bool,
     ) -> Result<()> {
-        self.spirc.activate().ok();
         let options = LoadRequestOptions {
             start_playing: true,
             seek_to: position_ms,
-            context_options: shuffle.then(|| {
-                LoadContextOptions::Options(CtxOptions {
-                    shuffle: true,
-                    ..Default::default()
-                })
-            }),
+            context_options: context_options(shuffle),
             playing_track: track_uri.map(PlayingTrack::Uri),
         };
-        self.spirc
-            .load(LoadRequest::from_context_uri(context_uri, options))
-            .context("load context at")?;
-        Ok(())
+        self.command("load context at", |spirc| {
+            spirc.activate().ok();
+            spirc.load(LoadRequest::from_context_uri(context_uri, options))
+        })
     }
 
     /// Play an explicit list of track URIs as a context. `start_uri` picks the
@@ -135,82 +193,85 @@ impl Engine {
         start_position_ms: u32,
         shuffle: bool,
     ) -> Result<()> {
-        self.spirc.activate().ok();
         let options = LoadRequestOptions {
             start_playing: true,
-            context_options: shuffle.then(|| {
-                LoadContextOptions::Options(CtxOptions {
-                    shuffle: true,
-                    ..Default::default()
-                })
-            }),
+            context_options: context_options(shuffle),
             playing_track: start_uri.map(PlayingTrack::Uri),
             seek_to: start_position_ms,
         };
-        self.spirc
-            .load(LoadRequest::from_tracks(tracks, options))
-            .context("load tracks")?;
-        Ok(())
+        self.command("load tracks", |spirc| {
+            spirc.activate().ok();
+            spirc.load(LoadRequest::from_tracks(tracks, options))
+        })
     }
 
     /// Load a single track and start playing at `position_ms` — used to resume
     /// the last session's track when the user first hits play.
     pub fn play_track_at(&self, uri: String, position_ms: u32) -> Result<()> {
-        self.spirc.activate().ok();
         let options = LoadRequestOptions {
             start_playing: true,
             seek_to: position_ms,
             ..Default::default()
         };
-        self.spirc
-            .load(LoadRequest::from_tracks(vec![uri], options))
-            .context("resume track")?;
-        Ok(())
+        self.command("resume track", |spirc| {
+            spirc.activate().ok();
+            spirc.load(LoadRequest::from_tracks(vec![uri], options))
+        })
     }
 
     pub fn play(&self) -> Result<()> {
-        self.spirc.play().context("play")
+        self.command("play", Spirc::play)
     }
     pub fn pause(&self) -> Result<()> {
-        self.spirc.pause().context("pause")
+        self.command("pause", Spirc::pause)
     }
     pub fn stop(&self) {
-        self.player.stop()
+        self.inner.link().player.stop()
     }
     pub fn toggle(&self) -> Result<()> {
-        self.spirc.play_pause().context("toggle")
+        self.command("toggle", Spirc::play_pause)
     }
     pub fn next(&self) -> Result<()> {
-        self.spirc.next().context("next")
+        self.command("next", Spirc::next)
     }
     pub fn prev(&self) -> Result<()> {
-        self.spirc.prev().context("prev")
+        self.command("prev", Spirc::prev)
     }
     pub fn shuffle(&self, on: bool) -> Result<()> {
-        self.spirc.shuffle(on).context("shuffle")
+        self.command("shuffle", |spirc| spirc.shuffle(on))
     }
     pub fn repeat(&self, on: bool) -> Result<()> {
-        self.spirc.repeat(on).context("repeat")
+        self.command("repeat", |spirc| spirc.repeat(on))
     }
     /// Set volume in librespot's 0..=65535 range.
     pub fn set_volume(&self, vol: u16) -> Result<()> {
         // Apply to the local software mixer immediately (no network round-trip).
-        self.mixer.set_volume(vol);
+        self.inner.mixer.set_volume(vol);
         // Sync the volume to Spotify Connect in the background.
-        self.spirc.set_volume(vol).context("set volume")
+        self.command("set volume", |spirc| spirc.set_volume(vol))
     }
     /// Seek to an absolute position in the current track.
     pub fn seek(&self, position_ms: u32) -> Result<()> {
-        self.spirc.set_position_ms(position_ms).context("seek")
+        self.command("seek", |spirc| spirc.set_position_ms(position_ms))
     }
     /// This device's Spotify Connect id — used to transfer playback back to myx.
     pub fn device_id(&self) -> String {
-        self.session.device_id().to_string()
+        self.inner.link().session.device_id().to_string()
     }
     /// A cheap clone of the session (for off-thread mercury calls like radio).
     pub fn session(&self) -> Session {
-        self.session.clone()
+        self.inner.link().session.clone()
     }
+}
+
+/// Server-side shuffle options, or `None` to leave the context's own order.
+fn context_options(shuffle: bool) -> Option<LoadContextOptions> {
+    shuffle.then(|| {
+        LoadContextOptions::Options(CtxOptions {
+            shuffle: true,
+            ..Default::default()
+        })
+    })
 }
 
 /// Fetch a track-seeded radio station via librespot's internal mercury protocol
@@ -328,15 +389,40 @@ pub async fn run(
     tx: flume::Sender<EngineEvent>,
     initial_volume_pct: u8,
 ) -> Result<Engine> {
-    let cache = build_cache()?;
-    let session = Session::new(SessionConfig::default(), Some(cache));
-
     let bands = VisBands::shared();
 
     // 50% volume in librespot's 0..=65535 range.
     let volume: u16 = (u32::from(initial_volume_pct.clamp(0, 100)) * 65535 / 100) as u16;
     let mixer = Arc::new(SoftMixer::open(MixerConfig::default()).context("open softmixer")?);
     mixer.set_volume(volume);
+
+    let link = connect(&creds, &mixer, &bands, &tx).await?;
+    let inner = Arc::new(Inner {
+        link: Mutex::new(Arc::new(link)),
+        mixer,
+        bands: Arc::clone(&bands),
+        events: tx,
+        creds,
+    });
+    spawn_watchdog(&inner);
+
+    Ok(Engine { bands, inner })
+}
+
+/// Bring up a session, a player and a Connect device, and bridge the player's
+/// events onto `events`. This is what a reconnect rebuilds.
+async fn connect(
+    first_login: &Credentials,
+    mixer: &Arc<SoftMixer>,
+    bands: &Arc<Mutex<VisBands>>,
+    events: &flume::Sender<EngineEvent>,
+) -> Result<Link> {
+    let cache = build_cache()?;
+    // Prefer the reusable credentials librespot stores on a successful login:
+    // `first_login` may be the one-shot OAuth token from a first run, which
+    // Spotify would refuse hours later.
+    let creds = cache.credentials().unwrap_or_else(|| first_login.clone());
+    let session = Session::new(SessionConfig::default(), Some(cache));
 
     let backend = audio_backend::find(None).expect("an audio backend should be available");
     let player_config = PlayerConfig {
@@ -345,7 +431,7 @@ pub async fn run(
     };
 
     let player = {
-        let bands = Arc::clone(&bands);
+        let bands = Arc::clone(bands);
         Player::new(
             player_config,
             session.clone(),
@@ -361,7 +447,8 @@ pub async fn run(
     // `is_active` flag here (the sink fills the bands, but only playback state
     // knows whether audio is actually flowing).
     let mut channel = player.get_player_event_channel();
-    let ev_bands = Arc::clone(&bands);
+    let ev_bands = Arc::clone(bands);
+    let tx = events.clone();
     tokio::spawn(async move {
         while let Some(ev) = channel.recv().await {
             match &ev {
@@ -388,7 +475,9 @@ pub async fn run(
     let connect_config = ConnectConfig {
         name: "myx".to_string(),
         device_type: DeviceType::Computer,
-        initial_volume: volume,
+        // Carry the live volume across a reconnect — the mixer outlives the
+        // connection, so the new device must not announce a stale level.
+        initial_volume: mixer.volume(),
         is_group: false,
         disable_volume: false,
         volume_steps: 64,
@@ -405,11 +494,76 @@ pub async fn run(
     .context("initialize spirc")?;
     tokio::spawn(spirc_task);
 
-    Ok(Engine {
+    Ok(Link {
         spirc,
-        bands,
         player,
-        mixer,
         session,
     })
+}
+
+/// How often the watchdog asks whether the access point is still there. The
+/// check is a lock read; only an actual reconnect costs anything.
+const HEALTH_CHECK: Duration = Duration::from_secs(5);
+/// First and last wait between failed reconnects, so a laptop closed overnight
+/// with no network doesn't resolve access points every five seconds until dawn.
+const RETRY_MIN: Duration = Duration::from_secs(5);
+const RETRY_MAX: Duration = Duration::from_secs(120);
+
+fn next_backoff(current: Duration) -> Duration {
+    (current * 2).min(RETRY_MAX)
+}
+
+/// Rebuild the connection whenever the access point drops it.
+///
+/// librespot marks the session invalid on a keep-alive timeout and leaves
+/// recovery to the caller (`session.rs`: "TODO: Optionally reconnect"). Without
+/// this, an idle myx wakes up to every command failing with a closed channel,
+/// and the only fix is a restart. Polling means the repair usually lands long
+/// before anyone presses a key.
+fn spawn_watchdog(inner: &Arc<Inner>) {
+    let weak = Arc::downgrade(inner);
+    tokio::spawn(async move {
+        let mut backoff = RETRY_MIN;
+        loop {
+            tokio::time::sleep(HEALTH_CHECK).await;
+            // Gone means myx is quitting; the watchdog must not be what keeps
+            // the Connect device alive.
+            let Some(inner) = weak.upgrade() else {
+                return;
+            };
+            if !inner.is_stale() {
+                backoff = RETRY_MIN;
+                continue;
+            }
+            let _ = inner.events.send(EngineEvent::Reconnecting);
+            let failed = inner.reconnect().await.is_err();
+            if !failed {
+                backoff = RETRY_MIN;
+                let _ = inner.events.send(EngineEvent::Reconnected);
+                continue;
+            }
+            // Hold nothing across the wait, or quitting blocks on it.
+            drop(inner);
+            tokio::time::sleep(backoff).await;
+            backoff = next_backoff(backoff);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_failing_reconnect_backs_off_up_to_the_cap() {
+        assert!(next_backoff(RETRY_MIN) > RETRY_MIN);
+        let mut wait = RETRY_MIN;
+        for _ in 0..10 {
+            wait = next_backoff(wait);
+            assert!(wait <= RETRY_MAX, "{wait:?} is past the cap");
+        }
+        // An offline night must settle at the cap rather than grow without
+        // bound — the watchdog has to still be trying when the network returns.
+        assert_eq!(wait, RETRY_MAX);
+    }
 }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -149,6 +149,20 @@ impl Engine {
         })
     }
 
+    /// A [`Self::command`] that first reclaims the active-device role, which
+    /// Spotify revokes from an idle paused device. Once revoked, librespot
+    /// discards every other command; `Activate` is the one it still honours,
+    /// and it no-ops when we are already active. Volume stays out of here — it
+    /// must never yank playback off whatever device actually holds it.
+    fn active_command<T>(
+        &self,
+        what: &'static str,
+        f: impl FnOnce(&Spirc) -> Result<T, librespot_core::Error>,
+    ) -> Result<T> {
+        let _ = self.inner.link().spirc.activate();
+        self.command(what, f)
+    }
+
     /// Start playing a context (playlist / album / artist / track URI). When
     /// `shuffle` is set, Spotify shuffles the *entire* context server-side.
     pub fn play_context(&self, context_uri: impl Into<String>, shuffle: bool) -> Result<()> {
@@ -157,8 +171,7 @@ impl Engine {
             context_options: context_options(shuffle),
             ..Default::default()
         };
-        self.command("load context", |spirc| {
-            spirc.activate().ok();
+        self.active_command("load context", |spirc| {
             spirc.load(LoadRequest::from_context_uri(context_uri.into(), options))
         })
     }
@@ -177,8 +190,7 @@ impl Engine {
             context_options: context_options(shuffle),
             playing_track: track_uri.map(PlayingTrack::Uri),
         };
-        self.command("load context at", |spirc| {
-            spirc.activate().ok();
+        self.active_command("load context at", |spirc| {
             spirc.load(LoadRequest::from_context_uri(context_uri, options))
         })
     }
@@ -199,8 +211,7 @@ impl Engine {
             playing_track: start_uri.map(PlayingTrack::Uri),
             seek_to: start_position_ms,
         };
-        self.command("load tracks", |spirc| {
-            spirc.activate().ok();
+        self.active_command("load tracks", |spirc| {
             spirc.load(LoadRequest::from_tracks(tracks, options))
         })
     }
@@ -213,35 +224,34 @@ impl Engine {
             seek_to: position_ms,
             ..Default::default()
         };
-        self.command("resume track", |spirc| {
-            spirc.activate().ok();
+        self.active_command("resume track", |spirc| {
             spirc.load(LoadRequest::from_tracks(vec![uri], options))
         })
     }
 
     pub fn play(&self) -> Result<()> {
-        self.command("play", Spirc::play)
+        self.active_command("play", Spirc::play)
     }
     pub fn pause(&self) -> Result<()> {
-        self.command("pause", Spirc::pause)
+        self.active_command("pause", Spirc::pause)
     }
     pub fn stop(&self) {
         self.inner.link().player.stop()
     }
     pub fn toggle(&self) -> Result<()> {
-        self.command("toggle", Spirc::play_pause)
+        self.active_command("toggle", Spirc::play_pause)
     }
     pub fn next(&self) -> Result<()> {
-        self.command("next", Spirc::next)
+        self.active_command("next", Spirc::next)
     }
     pub fn prev(&self) -> Result<()> {
-        self.command("prev", Spirc::prev)
+        self.active_command("prev", Spirc::prev)
     }
     pub fn shuffle(&self, on: bool) -> Result<()> {
-        self.command("shuffle", |spirc| spirc.shuffle(on))
+        self.active_command("shuffle", |spirc| spirc.shuffle(on))
     }
     pub fn repeat(&self, on: bool) -> Result<()> {
-        self.command("repeat", |spirc| spirc.repeat(on))
+        self.active_command("repeat", |spirc| spirc.repeat(on))
     }
     /// Set volume in librespot's 0..=65535 range.
     pub fn set_volume(&self, vol: u16) -> Result<()> {
@@ -252,7 +262,7 @@ impl Engine {
     }
     /// Seek to an absolute position in the current track.
     pub fn seek(&self, position_ms: u32) -> Result<()> {
-        self.command("seek", |spirc| spirc.set_position_ms(position_ms))
+        self.active_command("seek", |spirc| spirc.set_position_ms(position_ms))
     }
     /// This device's Spotify Connect id — used to transfer playback back to myx.
     pub fn device_id(&self) -> String {
@@ -426,7 +436,10 @@ async fn connect(
 
     let backend = audio_backend::find(None).expect("an audio backend should be available");
     let player_config = PlayerConfig {
-        position_update_interval: Some(Duration::from_millis(100)),
+        // Each correction pushes the whole Connect state to Spotify, so the old
+        // 100ms announced us ten times a second. Position is extrapolated
+        // locally; this only trims the drift.
+        position_update_interval: Some(Duration::from_secs(1)),
         ..Default::default()
     };
 

--- a/src/httpcache.rs
+++ b/src/httpcache.rs
@@ -1,0 +1,182 @@
+//! On-disk cache for catalogue reads (`~/.cache/myx/api`).
+//!
+//! Spotify's development-mode quota is per app, and it runs out: an artist
+//! drill-in costs four requests, so a few minutes of browsing can earn a `429`
+//! with a `Retry-After` measured in hours. Cached bodies keep repeat visits off
+//! the network entirely, and a stale entry is served when the request fails —
+//! an album list from yesterday beats an empty page.
+//!
+//! Only immutable-ish catalogue data belongs here. Anything the user can change
+//! (playback state, saved-track flags) must go straight to the API.
+
+use std::fs;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// Entries older than this are swept once per run. Album art is the bulk of it
+/// — a few hundred KB a day, which would otherwise just accumulate forever.
+const KEEP: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+/// Where a URL's cached body lives. The hash keeps tokens and query strings out
+/// of the filename.
+fn path_in(dir: &Path, url: &str) -> PathBuf {
+    let mut h = DefaultHasher::new();
+    url.hash(&mut h);
+    dir.join(format!("{:016x}", h.finish()))
+}
+
+fn dir() -> Option<&'static Path> {
+    static DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
+    DIR.get_or_init(|| {
+        let dir = crate::home_dir()?.join(".cache/myx/api");
+        fs::create_dir_all(&dir).ok()?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&dir, fs::Permissions::from_mode(0o700));
+        }
+        sweep(&dir, KEEP);
+        Some(dir)
+    })
+    .as_deref()
+}
+
+/// Drop entries nobody has asked for in a month. Runs once, on the first cache
+/// hit of the session.
+fn sweep(dir: &Path, keep: Duration) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.elapsed().ok())
+            .is_some_and(|age| age > keep);
+        if stale {
+            let _ = fs::remove_file(entry.path());
+        }
+    }
+}
+
+/// A cached body younger than `max_age`, or any age when `max_age` is `None`.
+pub fn get(url: &str, max_age: Option<Duration>) -> Option<String> {
+    get_in(dir()?, url, max_age)
+}
+
+pub fn put(url: &str, body: &str) {
+    if let Some(dir) = dir() {
+        put_in(dir, url, body);
+    }
+}
+
+fn get_in(dir: &Path, url: &str, max_age: Option<Duration>) -> Option<String> {
+    let path = path_in(dir, url);
+    if let Some(max_age) = max_age {
+        let age = fs::metadata(&path)
+            .and_then(|m| m.modified())
+            .ok()?
+            .elapsed()
+            .ok()?;
+        if age > max_age {
+            return None;
+        }
+    }
+    fs::read_to_string(&path).ok()
+}
+
+fn put_in(dir: &Path, url: &str, body: &str) {
+    write_atomic(&path_in(dir, url), body.as_bytes());
+}
+
+/// Album art, keyed the same way. Spotify's image URLs embed a content hash, so
+/// a cached file never goes stale — the URL changes when the picture does.
+pub fn get_bytes(url: &str) -> Option<Vec<u8>> {
+    fs::read(path_in(dir()?, url)).ok()
+}
+
+pub fn put_bytes(url: &str, bytes: &[u8]) {
+    if let Some(dir) = dir() {
+        write_atomic(&path_in(dir, url), bytes);
+    }
+}
+
+/// Write via a temporary file and rename, so a kill mid-write can't leave a
+/// truncated entry behind — image bytes never expire, and a corrupt one would
+/// mean a cover that stays broken forever.
+fn write_atomic(path: &Path, bytes: &[u8]) {
+    let tmp = path.with_extension("tmp");
+    if fs::write(&tmp, bytes).is_ok() && fs::rename(&tmp, path).is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("myx-httpcache-{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn a_miss_reads_nothing() {
+        let dir = scratch("miss");
+        assert_eq!(get_in(&dir, "https://x/albums", Some(Duration::MAX)), None);
+    }
+
+    #[test]
+    fn a_fresh_entry_comes_back() {
+        let dir = scratch("fresh");
+        put_in(&dir, "https://x/albums", "{\"items\":[]}");
+        assert_eq!(
+            get_in(&dir, "https://x/albums", Some(Duration::from_secs(60))),
+            Some("{\"items\":[]}".to_string())
+        );
+    }
+
+    #[test]
+    fn an_expired_entry_is_a_miss_but_still_readable() {
+        let dir = scratch("expired");
+        put_in(&dir, "https://x/albums", "old");
+        // Zero TTL expires it immediately; the stale read (no max_age) is what
+        // rescues a drill-in when the quota is spent.
+        assert_eq!(get_in(&dir, "https://x/albums", Some(Duration::ZERO)), None);
+        assert_eq!(
+            get_in(&dir, "https://x/albums", None),
+            Some("old".to_string())
+        );
+    }
+
+    #[test]
+    fn a_sweep_keeps_fresh_entries_and_survives_an_empty_dir() {
+        let dir = scratch("sweep");
+        sweep(&dir, Duration::ZERO); // empty dir, nothing to do
+        put_in(&dir, "https://x/albums", "fresh");
+        sweep(&dir, KEEP);
+        assert_eq!(
+            get_in(&dir, "https://x/albums", None),
+            Some("fresh".to_string())
+        );
+        // Everything is stale at zero age, so this clears the entry.
+        sweep(&dir, Duration::ZERO);
+        assert_eq!(get_in(&dir, "https://x/albums", None), None);
+    }
+
+    #[test]
+    fn different_urls_do_not_share_an_entry() {
+        let dir = scratch("keys");
+        put_in(&dir, "https://x/artists/1/albums", "one");
+        put_in(&dir, "https://x/artists/2/albums", "two");
+        assert_eq!(
+            get_in(&dir, "https://x/artists/1/albums", None),
+            Some("one".to_string())
+        );
+    }
+}

--- a/src/httpcache.rs
+++ b/src/httpcache.rs
@@ -12,6 +12,7 @@
 use std::fs;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -107,8 +108,13 @@ pub fn put_bytes(url: &str, bytes: &[u8]) {
 /// Write via a temporary file and rename, so a kill mid-write can't leave a
 /// truncated entry behind — image bytes never expire, and a corrupt one would
 /// mean a cover that stays broken forever.
+///
+/// The temp name carries a counter because two library threads can fetch the
+/// same URL at once; sharing one scratch file would interleave their writes into
+/// a corrupt entry that then never expires.
 fn write_atomic(path: &Path, bytes: &[u8]) {
-    let tmp = path.with_extension("tmp");
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let tmp = path.with_extension(format!("{}.tmp", SEQ.fetch_add(1, Ordering::Relaxed)));
     if fs::write(&tmp, bytes).is_ok() && fs::rename(&tmp, path).is_err() {
         let _ = fs::remove_file(&tmp);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod color;
 pub mod components;
 pub mod cover;
 pub mod gradient;
+pub mod httpcache;
 pub mod reactive;
 pub mod theme;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ use souvlaki::{
 };
 
 type Term = Terminal<CrosstermBackend<Stdout>>;
-const FADE_MS: u64 = 1200;
+const FADE_MS: u64 = 1500;
 
 /// How far one Shift+arrow press moves the playhead.
 const SEEK_STEP_MS: i64 = 5_000;
@@ -783,6 +783,7 @@ impl App {
 // ------------------------------------------------------------------ main
 
 fn main() -> Result<()> {
+    install_librespot_log();
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     // Refuse to start a second instance — two myx's racing on the shared Web API
@@ -2369,6 +2370,10 @@ fn advance_fade(app: &mut App) {
 }
 
 fn handle_engine_event(app: &mut App, ev: EngineEvent, meta_tx: &flume::Sender<TrackMeta>) {
+    // Position ticks would bury everything else in the log.
+    if !matches!(ev, EngineEvent::PositionCorrection { .. }) {
+        liblog(format!("engine: {ev:?}"));
+    }
     match ev {
         EngineEvent::TrackChanged { uri } => {
             app.status = "loading track…".to_string();
@@ -2415,6 +2420,9 @@ fn handle_engine_event(app: &mut App, ev: EngineEvent, meta_tx: &flume::Sender<T
         EngineEvent::Stopped => {
             app.now = None;
             app.playback_started = false;
+            // librespot cleared its context too, so only a fresh load can
+            // resume from here — not a bare `play`.
+            app.reclaimed = false;
 
             if let Some(controls) = app.media_controls.as_mut() {
                 let _ = controls.set_playback(MediaPlayback::Stopped);
@@ -2538,6 +2546,45 @@ fn apply_meta(
 
 /// Temporary-but-useful diagnostics for startup/library failures. Kept out of
 /// the TUI because alternate-screen rendering hides stderr.
+/// Forwards librespot's own `log` output into `myx.log`. Its Connect
+/// diagnostics are the only account of why the device went inactive, and
+/// without a logger installed they go nowhere.
+struct LibrespotLog;
+
+impl log::Log for LibrespotLog {
+    fn enabled(&self, _: &log::Metadata) -> bool {
+        true
+    }
+    fn log(&self, record: &log::Record) {
+        liblog(format!(
+            "{} {}: {}",
+            record.level(),
+            record.target(),
+            record.args()
+        ));
+    }
+    fn flush(&self) {}
+}
+
+/// Any value of `MYX_LOG` turns logging on; the value only picks how loud
+/// librespot is. `debug`/`trace` open it up, `warn` quiets it back down.
+fn install_librespot_log() {
+    let Ok(level) = std::env::var("MYX_LOG") else {
+        return;
+    };
+    let filter = match level.to_ascii_lowercase().as_str() {
+        "trace" => log::LevelFilter::Trace,
+        "debug" => log::LevelFilter::Debug,
+        "warn" => log::LevelFilter::Warn,
+        // Connect names its own faults at info ("device became inactive");
+        // warn shows only the fallout.
+        _ => log::LevelFilter::Info,
+    };
+    if log::set_boxed_logger(Box::new(LibrespotLog)).is_ok() {
+        log::set_max_level(filter);
+    }
+}
+
 /// Optional debug log — silent unless `MYX_LOG` is set. Writes to
 /// ~/.cache/myx/myx.log (user-owned dir 0700, file 0600) instead of a
 /// world-writable fixed /tmp path (audit H5).

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,34 @@ const ART_REPAINTS: u8 = 2;
 
 /// How often the cover is re-sent anyway. tmux only forwards focus changes with
 /// `focus-events on`, so without a timer the art stays gone after a window switch.
+/// Every resend re-encodes and retransmits the whole image, so it runs under tmux
+/// only — elsewhere `FocusGained` covers it.
 const ART_RESEND: Duration = Duration::from_secs(2);
+
+/// Ceiling on the redraw rate: one frame per ~60Hz terminal refresh.
+const MIN_FRAME: Duration = Duration::from_millis(16);
+/// Redraw rate while the visualizer or a theme fade is running.
+const ANIM_FRAME: Duration = Duration::from_millis(33);
+/// Redraw rate when nothing changed — enough to keep the clock and progress bar
+/// honest without repainting an identical frame 60 times a second.
+const IDLE_REDRAW: Duration = Duration::from_millis(500);
+/// How often the live queue is re-fetched and the session persisted.
+const SYNC_EVERY: Duration = Duration::from_secs(24);
+
+/// Whether this frame is worth drawing.
+///
+/// Input beats animation beats the idle clock: a keypress redraws within one
+/// terminal refresh, so a held arrow scrolls smoothly, while an untouched
+/// screen redraws twice a second instead of sixty times.
+fn should_draw(dirty: bool, animating: bool, since_last: Duration) -> bool {
+    if dirty {
+        since_last >= MIN_FRAME
+    } else if animating {
+        since_last >= ANIM_FRAME
+    } else {
+        since_last >= IDLE_REDRAW
+    }
+}
 
 // ------------------------------------------------------------------ model
 
@@ -824,7 +851,14 @@ async fn boot(
         let _ = engine.play_context(uri, false);
     }
 
-    let picker = Cover::make_picker();
+    let picker = Cover::make_picker(myx::config::get().protocol.as_deref());
+    // Halfblocks here means the graphics query got no answer — the art will look
+    // like a 25×26 mosaic. MYX_PROTOCOL overrides it.
+    liblog(format!(
+        "cover: {:?}, font {:?}",
+        picker.protocol_type(),
+        picker.font_size()
+    ));
 
     // Rebuild the last now-playing (paused) for a seamless resume look.
     let now = saved.last_played.as_ref().map(|last_played| NowPlaying {
@@ -998,7 +1032,6 @@ async fn run_ui(
     }
     let mut media_events_open = true;
 
-    let mut frame_count: u64 = 0;
     let mut lib_attempts: u32 = 0;
     // A persistent interval must live OUTSIDE the select loop. Recreating a
     // `sleep()` every loop starves forever when player events are continuously
@@ -1006,11 +1039,19 @@ async fn run_ui(
     // frozen-UI bug.
     let mut frame = tokio::time::interval(Duration::from_millis(16));
     frame.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    let mut last_draw = Instant::now() - Duration::from_millis(100);
+    let mut last_draw = Instant::now() - IDLE_REDRAW;
     let mut last_art_resend = Instant::now();
+    let mut last_sync = Instant::now();
+    // Nothing is on screen yet, so the first tick must draw.
+    let mut dirty = true;
+    let mut last_layout = (app.view, app.zen);
+    // The resend timer only exists for terminals that never report focus. tmux
+    // is the one that does this by default (`focus-events off`), and the first
+    // focus event it does forward retires the timer for good.
+    let mut art_resend = std::env::var_os("TMUX").is_some();
 
     loop {
-        tokio::select! {
+        let touched = tokio::select! {
             biased;
             _ = frame.tick() => {
                 app.flush_seek(Instant::now());
@@ -1019,6 +1060,7 @@ async fn run_ui(
                 // stream / 60fps visualizer — which looked like a frozen library.
                 while let Ok((section, mut items)) = lib_rx.try_recv() {
                     let count = items.len();
+                    dirty = true;
                     liblog(format!("ui: received {} rows for {}", count, section.label()));
                     for (i, it) in items.iter_mut().enumerate() {
                         it.order = i as u32;
@@ -1031,6 +1073,7 @@ async fn run_ui(
                     app.status = format!("loaded {}", section.label());
                 }
                 while let Ok(got_any) = libdone_rx.try_recv() {
+                    dirty = true;
                     if got_any {
                         lib_attempts = 0;
                         app.status.clear();
@@ -1046,6 +1089,7 @@ async fn run_ui(
                 // same reason as the library: under the biased 16ms frame tick a
                 // pure recv arm starves and the station never plays.
                 while let Ok(rad) = radio_rx.try_recv() {
+                    dirty = true;
                     match rad {
                         Ok(radio) if !radio.uris.is_empty() => {
                             if let Err(e) = app.engine.play_tracks(radio.uris, None, radio.start_position_ms, false) {
@@ -1070,14 +1114,31 @@ async fn run_ui(
                     }
                 }
 
+                // Only the Now Playing pane animates; on Lyrics or Queue the
+                // visualizer is off-screen and its frame rate buys nothing.
                 let animating = app.fade.is_some()
-                    || app.engine.bands.try_lock().map(|g| g.is_active).unwrap_or(false);
-                let target = Duration::from_millis(if animating { 16 } else { 100 });
-                if app.view == RightView::NowPlaying && last_art_resend.elapsed() >= ART_RESEND {
+                    || (app.view == RightView::NowPlaying
+                        && app.engine.bands.try_lock().map(|g| g.is_active).unwrap_or(false));
+                if art_resend
+                    && app.view == RightView::NowPlaying
+                    && last_art_resend.elapsed() >= ART_RESEND
+                {
                     last_art_resend = Instant::now();
                     app.art_dirty = app.art_dirty.max(1);
+                    dirty = true;
                 }
-                if last_draw.elapsed() >= target {
+                if app.art_dirty > 0 {
+                    dirty = true;
+                }
+                // Switching away and back drops the image data on the
+                // terminal's side; the placeholder cells alone then point at
+                // nothing and whatever the other view drew shows through.
+                if (app.view, app.zen) != last_layout {
+                    last_layout = (app.view, app.zen);
+                    app.art_dirty = ART_REPAINTS;
+                    dirty = true;
+                }
+                if should_draw(dirty, animating, last_draw.elapsed()) {
                     advance_fade(&mut app);
                     // Inline images are written once by ratatui; invalidate so
                     // the re-encode produces a fresh cell.
@@ -1091,9 +1152,10 @@ async fn run_ui(
                     }
                     terminal.draw(|f| render(f, &mut app))?;
                     last_draw = Instant::now();
-                    frame_count += 1;
+                    dirty = false;
                 }
-                if frame_count > 0 && frame_count.is_multiple_of(240) {
+                if last_sync.elapsed() >= SYNC_EVERY {
+                    last_sync = Instant::now();
                     // Refresh the live queue while playing so the snapshot stays
                     // current, then persist it (survives reboot).
                     if app.playback_started || app.reclaimed {
@@ -1101,10 +1163,12 @@ async fn run_ui(
                     }
                     save_state(&app);
                 }
+                false
             }
             ev = ev_rx.recv_async() => {
                 let Ok(ev) = ev else { break };
                 handle_engine_event(&mut app, ev, &meta_tx);
+                true
             }
             ev = in_rx.recv_async() => {
                 match ev {
@@ -1240,17 +1304,18 @@ async fn run_ui(
                             }
                             _ => {}
                         }
-                        // Force immediate redraw so the volume meter updates without
-                        // waiting for the next 100ms idle tick.
-                        last_draw = Instant::now() - Duration::from_millis(200);
                     }
                     // A repaint from the terminal's own buffer loses inline art.
-                    Ok(Event::Resize(..)) | Ok(Event::FocusGained) => {
+                    Ok(Event::Resize(..)) => app.art_dirty = ART_REPAINTS,
+                    // Focus is reported, so the timer has nothing left to cover.
+                    Ok(Event::FocusGained) => {
+                        art_resend = false;
                         app.art_dirty = ART_REPAINTS;
-                        last_draw = Instant::now() - Duration::from_millis(200);
                     }
+                    Ok(Event::FocusLost) => art_resend = false,
                     _ => {}
                 }
+                true
             }
             ev = souvlaki_rx.recv_async(), if media_events_open => {
                 match consume_media_event(ev, &mut media_events_open) {
@@ -1260,9 +1325,11 @@ async fn run_ui(
                         liblog("media controls event channel closed; native integration disabled");
                     }
                 }
+                true
             }
             m = meta_rx.recv_async() => {
                 if let Ok(meta) = m { apply_meta(&mut app, meta, &lyrics_tx); }
+                true
             }
             q = queue_rx.recv_async() => {
                 // Don't let an empty live queue (e.g. a bare resumed track) wipe
@@ -1273,6 +1340,7 @@ async fn run_ui(
                         app.queue_uris = q.into_iter().map(|(_, u)| u).collect();
                     }
                 }
+                true
             }
             s = search_rx.recv_async() => {
                 if let Ok(results) = s {
@@ -1284,12 +1352,14 @@ async fn run_ui(
                         String::new()
                     };
                 }
+                true
             }
             ly = lyrics_rx.recv_async() => {
                 if let Ok((lines, synced)) = ly {
                     app.lyrics = lines;
                     app.lyrics_synced = synced;
                 }
+                true
             }
             d = detail_rx.recv_async() => {
                 if let Ok((context_uri, title, items)) = d {
@@ -1297,6 +1367,7 @@ async fn run_ui(
                     app.selected = app.first_selectable();
                     app.status.clear();
                 }
+                true
             }
             menu = menu_rx.recv_async() => {
                 if let Ok(mut menu) = menu {
@@ -1309,9 +1380,11 @@ async fn run_ui(
                         app.actions = Some(menu);
                     }
                 }
+                true
             }
             st = astatus_rx.recv_async() => {
                 if let Ok(msg) = st { app.status = msg; }
+                true
             }
             ps = pstate_rx.recv_async() => {
                 if let Ok(state) = ps {
@@ -1338,8 +1411,10 @@ async fn run_ui(
                     tokio::task::spawn_blocking(move || { let _ = tx.send(fetch_track_meta(&webapi, &id)); });
                     spawn_queue_fetch(app.webapi.clone(), queue_tx.clone());
                 }
+                true
             }
-        }
+        };
+        dirty |= touched;
     }
     Ok(())
 }
@@ -1909,7 +1984,7 @@ fn build_action_menu(token: Option<&str>, item: &LibItem) -> ActionMenu {
             if let Some(v) = client
                 .as_ref()
                 .zip(token)
-                .and_then(|(c, t)| get_json(c, &format!("{API}/tracks/{id}"), t))
+                .and_then(|(c, t)| get_json_cached(c, &format!("{API}/tracks/{id}"), t))
             {
                 if let (Some(au), Some(an)) = (
                     v["artists"][0]["uri"].as_str(),
@@ -2003,7 +2078,7 @@ fn build_action_menu(token: Option<&str>, item: &LibItem) -> ActionMenu {
             if let Some(v) = client
                 .as_ref()
                 .zip(token)
-                .and_then(|(c, t)| get_json(c, &format!("{API}/albums/{id}"), t))
+                .and_then(|(c, t)| get_json_cached(c, &format!("{API}/albums/{id}"), t))
             {
                 if let (Some(au), Some(an)) = (
                     v["artists"][0]["uri"].as_str(),
@@ -2502,6 +2577,54 @@ fn get_json(
     None
 }
 
+/// How long a cached catalogue response counts as fresh. Discographies and
+/// track lists change on the order of weeks; a day keeps browsing off the
+/// network without anyone noticing the lag.
+const CATALOGUE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// `get_json` for catalogue reads, served from disk when possible.
+///
+/// On a failed request an expired entry is used rather than nothing — that is
+/// the case that matters, since a spent quota is exactly when the network stops
+/// answering and the artist page would otherwise come up empty.
+fn get_json_cached(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    token: &str,
+) -> Option<serde_json::Value> {
+    if let Some(body) = myx::httpcache::get(url, Some(CATALOGUE_TTL)) {
+        return serde_json::from_str(&body).ok();
+    }
+    match get_json(client, url, token) {
+        Some(v) => {
+            myx::httpcache::put(url, &v.to_string());
+            Some(v)
+        }
+        None => {
+            let stale = myx::httpcache::get(url, None)?;
+            liblog(format!("api: {url} failed; serving cached copy"));
+            serde_json::from_str(&stale).ok()
+        }
+    }
+}
+
+/// Album art bytes, from disk when they've been seen before.
+fn fetch_cover(client: &reqwest::blocking::Client, url: &str) -> Option<Vec<u8>> {
+    if let Some(bytes) = myx::httpcache::get_bytes(url) {
+        return Some(bytes);
+    }
+    let resp = client.get(url).send().ok()?;
+    // An error page cached as image bytes would be a permanently broken cover:
+    // the entry never expires, because the URL only changes with the picture.
+    if !resp.status().is_success() {
+        liblog(format!("cover: {url} -> HTTP {}", resp.status().as_u16()));
+        return None;
+    }
+    let bytes = resp.bytes().ok()?.to_vec();
+    myx::httpcache::put_bytes(url, &bytes);
+    Some(bytes)
+}
+
 /// Fetch the library incrementally: fast sections first, Liked streamed in
 /// chunks so the UI is usable within ~1s instead of waiting for everything.
 fn spawn_library_fetch(
@@ -2811,7 +2934,7 @@ fn fetch_track_meta(webapi: &Arc<Mutex<WebApi>>, track_id: &str) -> TrackMeta {
         return empty();
     };
     let client = http_client();
-    let Some(v) = get_json(&client, &format!("{API}/tracks/{track_id}"), &token) else {
+    let Some(v) = get_json_cached(&client, &format!("{API}/tracks/{track_id}"), &token) else {
         return empty();
     };
 
@@ -2821,10 +2944,10 @@ fn fetch_track_meta(webapi: &Arc<Mutex<WebApi>>, track_id: &str) -> TrackMeta {
     let duration_ms = v["duration_ms"].as_u64().unwrap_or(0) as u32;
     let cover_url = v["album"]["images"][0]["url"].as_str().map(String::from);
 
-    let image = cover_url.clone().and_then(|u| {
-        let bytes = client.get(u).send().ok()?.bytes().ok()?;
-        image::load_from_memory(&bytes).ok()
-    });
+    let image = cover_url
+        .clone()
+        .and_then(|u| fetch_cover(&client, &u))
+        .and_then(|bytes| image::load_from_memory(&bytes).ok());
     let theme = image.as_ref().map(|img| derive_theme(img, "album ✦"));
 
     TrackMeta {
@@ -3051,7 +3174,7 @@ fn artist_top_tracks(
         "{API}/search?q={}&type=track&limit=10",
         urlencode(&format!("artist:{name}"))
     );
-    let Some(v) = get_json(client, &url, token) else {
+    let Some(v) = get_json_cached(client, &url, token) else {
         return Vec::new();
     };
     v["tracks"]["items"]
@@ -3087,7 +3210,7 @@ fn artist_albums(client: &reqwest::blocking::Client, token: &str, id: &str) -> V
         if pages >= 3 {
             break; // 30 releases; more pages burn the API quota per drill-in
         }
-        let Some(v) = get_json(client, &u, token) else {
+        let Some(v) = get_json_cached(client, &u, token) else {
             break;
         };
         for a in v["items"].as_array().into_iter().flatten() {
@@ -3141,7 +3264,7 @@ fn fetch_detail_blocking(token: &str, uri: &str, name: &str) -> (String, Vec<Lib
             }
         }
         "album" => {
-            if let Some(v) = get_json(
+            if let Some(v) = get_json_cached(
                 &client,
                 &format!("{API}/albums/{id}/tracks?limit=50"),
                 token,
@@ -3675,8 +3798,11 @@ fn render_nowplaying_view(f: &mut Frame, app: &mut App, theme: Theme, area: Rect
         height: art_h,
     };
 
-    if let Some(cover) = app.now.as_mut().and_then(|n| n.cover.as_mut()) {
-        cover.render(f, art_rect);
+    match app.now.as_mut().and_then(|n| n.cover.as_mut()) {
+        Some(cover) => cover.render(f, art_rect),
+        // No art to draw over the cells another view left behind. They are only
+        // ever written by the image widget, so wipe them explicitly.
+        None => f.render_widget(Clear, art_rect),
     }
 
     if let Some(n) = app.now.as_ref() {
@@ -4729,6 +4855,32 @@ mod nav_tests {
         assert_eq!(scrub_target(2_000, 200_000, -5_000), 0);
         assert_eq!(scrub_target(198_000, 200_000, 5_000), 200_000);
         assert_eq!(scrub_target(0, 0, -5_000), 0);
+    }
+
+    // ----------------------------------------------------------- should_draw
+
+    #[test]
+    fn input_redraws_at_the_next_terminal_refresh() {
+        // What made a held arrow key scroll in jerks: the cursor had moved but
+        // the frame was held back until the idle tick came round.
+        assert!(should_draw(true, false, MIN_FRAME));
+        assert!(!should_draw(
+            true,
+            false,
+            MIN_FRAME - Duration::from_millis(1)
+        ));
+    }
+
+    #[test]
+    fn an_untouched_screen_redraws_rarely() {
+        assert!(!should_draw(false, false, ANIM_FRAME));
+        assert!(should_draw(false, false, IDLE_REDRAW));
+    }
+
+    #[test]
+    fn animation_redraws_between_the_two() {
+        assert!(should_draw(false, true, ANIM_FRAME));
+        assert!(!should_draw(false, true, MIN_FRAME));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,9 +16,11 @@ use crossterm::event::{
 };
 use crossterm::execute;
 use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+    disable_raw_mode, enable_raw_mode, BeginSynchronizedUpdate, EndSynchronizedUpdate,
+    EnterAlternateScreen, LeaveAlternateScreen,
 };
 use ratatui::backend::CrosstermBackend;
+use ratatui::buffer::CellDiffOption;
 use ratatui::layout::{Alignment, Constraint, Layout, Margin, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -41,7 +43,7 @@ use souvlaki::{
 };
 
 type Term = Terminal<CrosstermBackend<Stdout>>;
-const FADE_MS: u64 = 300;
+const FADE_MS: u64 = 1200;
 
 /// How far one Shift+arrow press moves the playhead.
 const SEEK_STEP_MS: i64 = 5_000;
@@ -55,22 +57,31 @@ fn scrub_target(from_ms: u32, duration_ms: u32, delta_ms: i64) -> u32 {
     (from_ms as i64 + delta_ms).clamp(0, duration_ms as i64) as u32
 }
 
-/// Frames to force a full repaint for after the album art changes.
+/// What the album art box owes the next frame.
 ///
-/// `ratatui-image` packs the entire encoded image into a single cell's symbol,
-/// and ratatui writes a cell only when it differs from the previous frame — so a
-/// new cover is transmitted exactly once. Terminals never acknowledge an inline
-/// image, and if that single write is dropped the symbol never changes again,
-/// leaving the previous track's art on screen indefinitely. Clearing invalidates
-/// the previous buffer so the same image gets written again; two frames allows
-/// one retry, costing two extra repaints per track change.
-const ART_REPAINTS: u8 = 2;
+/// `ratatui-image` puts the whole image in one cell's symbol and marks the rest
+/// of the box `Skip`, which the diff never touches again — so leftovers stay,
+/// and a re-encode is byte-identical for sixel and iTerm2 and gets discarded.
+/// Blanking the box for one frame is the only change the diff will emit, and it
+/// makes the image that follows one too.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ArtRepaint {
+    /// The box holds what it should.
+    Idle,
+    /// Blank the box this frame.
+    Wipe,
+    /// Draw the art; the wipe has gone out.
+    Draw,
+}
 
-/// How often the cover is re-sent anyway. tmux only forwards focus changes with
-/// `focus-events on`, so without a timer the art stays gone after a window switch.
-/// Every resend re-encodes and retransmits the whole image, so it runs under tmux
-/// only — elsewhere `FocusGained` covers it.
-const ART_RESEND: Duration = Duration::from_secs(2);
+impl ArtRepaint {
+    fn advance(self) -> Self {
+        match self {
+            Self::Wipe => Self::Draw,
+            _ => Self::Idle,
+        }
+    }
+}
 
 /// Ceiling on the redraw rate: one frame per ~60Hz terminal refresh.
 const MIN_FRAME: Duration = Duration::from_millis(16);
@@ -84,9 +95,10 @@ const SYNC_EVERY: Duration = Duration::from_secs(24);
 
 /// Whether this frame is worth drawing.
 ///
-/// Input beats animation beats the idle clock: a keypress redraws within one
-/// terminal refresh, so a held arrow scrolls smoothly, while an untouched
-/// screen redraws twice a second instead of sixty times.
+/// Input beats animation beats the idle clock. Smoothness of the recolour comes
+/// from its duration, not from the frame rate: every present makes the terminal
+/// recompose the viewport, and the inline cover shimmers if that happens 60
+/// times a second.
 fn should_draw(dirty: bool, animating: bool, since_last: Duration) -> bool {
     if dirty {
         since_last >= MIN_FRAME
@@ -496,17 +508,13 @@ struct App {
     details: Vec<Detail>,
     // Context actions menu overlay (opened with `a`).
     actions: Option<ActionMenu>,
-    // A last-played track URI to re-enrich (cover/theme/lyrics) on boot.
     restore_uri: Option<String>,
     // Track URI whose metadata was last requested. Fetches run on separate
     // blocking tasks and can land out of order when skipping quickly, so a
     // reply for any other track is stale and must be dropped.
     pending_meta: Option<String>,
-    // Blank plate drawn while a cover loads, cached alongside the colour it was
-    // built for so a theme change rebuilds it but an ordinary redraw does not.
-    // Frames still owed a forced repaint because the album art changed. See
-    // ART_REPAINTS — an inline image is written once and never retried.
-    art_dirty: u8,
+    // What the album art box owes the next frame. See ArtRepaint.
+    art_repaint: ArtRepaint,
     // Whether real playback has started this session (gates resume-on-play).
     playback_started: bool,
     // Whether we reclaimed a live server-side session (vs. local fallback).
@@ -774,8 +782,7 @@ impl App {
 
 // ------------------------------------------------------------------ main
 
-#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     // Refuse to start a second instance — two myx's racing on the shared Web API
@@ -805,7 +812,26 @@ async fn main() -> Result<()> {
         init_terminal,
     )?;
 
-    let res = boot(&mut terminal, saved, init_vol, creds, webapi).await;
+    // Query the terminal for its graphics protocol before anything else is
+    // running: picking sixel swaps `TERM` around the query, and `setenv` is only
+    // safe without concurrent readers. Hence the hand-built runtime below rather
+    // than `#[tokio::main]`, which would already have spawned its workers by the
+    // time this line ran.
+    let picker = Cover::make_picker(myx::config::get().protocol.as_deref());
+    // Halfblocks here means the graphics query got no answer — the art will look
+    // like a 25×26 mosaic. MYX_PROTOCOL overrides it.
+    liblog(format!(
+        "cover: {:?}, font {:?}",
+        picker.protocol_type(),
+        picker.font_size()
+    ));
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .context("start tokio runtime")?;
+    let res = runtime.block_on(boot(&mut terminal, saved, init_vol, creds, webapi, picker));
     restore_terminal(&mut terminal)?;
     res
 }
@@ -835,6 +861,7 @@ async fn boot(
     init_vol: u8,
     creds: librespot_core::authentication::Credentials,
     webapi: WebApi,
+    picker: Picker,
 ) -> Result<()> {
     let (ev_tx, ev_rx) = flume::unbounded::<EngineEvent>();
     let engine = with_loader(
@@ -850,15 +877,6 @@ async fn boot(
     if let Some(uri) = std::env::args().nth(1) {
         let _ = engine.play_context(uri, false);
     }
-
-    let picker = Cover::make_picker(myx::config::get().protocol.as_deref());
-    // Halfblocks here means the graphics query got no answer — the art will look
-    // like a 25×26 mosaic. MYX_PROTOCOL overrides it.
-    liblog(format!(
-        "cover: {:?}, font {:?}",
-        picker.protocol_type(),
-        picker.font_size()
-    ));
 
     // Rebuild the last now-playing (paused) for a seamless resume look.
     let now = saved.last_played.as_ref().map(|last_played| NowPlaying {
@@ -936,7 +954,7 @@ async fn boot(
         actions: None,
         restore_uri,
         pending_meta: None,
-        art_dirty: 0,
+        art_repaint: ArtRepaint::Idle,
         playback_started: false,
         reclaimed: false,
         source: saved.source.clone(),
@@ -1040,15 +1058,11 @@ async fn run_ui(
     let mut frame = tokio::time::interval(Duration::from_millis(16));
     frame.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut last_draw = Instant::now() - IDLE_REDRAW;
-    let mut last_art_resend = Instant::now();
     let mut last_sync = Instant::now();
     // Nothing is on screen yet, so the first tick must draw.
     let mut dirty = true;
     let mut last_layout = (app.view, app.zen);
-    // The resend timer only exists for terminals that never report focus. tmux
-    // is the one that does this by default (`focus-events off`), and the first
-    // focus event it does forward retires the timer for good.
-    let mut art_resend = std::env::var_os("TMUX").is_some();
+    let mut overlay_open = app.actions.is_some();
 
     loop {
         let touched = tokio::select! {
@@ -1114,43 +1128,44 @@ async fn run_ui(
                     }
                 }
 
-                // Only the Now Playing pane animates; on Lyrics or Queue the
-                // visualizer is off-screen and its frame rate buys nothing.
+                // The visualizer only animates while it is on screen; on Queue
+                // its frame rate buys nothing. Synced lyrics move too — at the
+                // idle rate the highlighted line lands half a second late.
                 let animating = app.fade.is_some()
+                    || (app.view == RightView::Lyrics && app.lyrics_synced)
                     || (app.view == RightView::NowPlaying
                         && app.engine.bands.try_lock().map(|g| g.is_active).unwrap_or(false));
-                if art_resend
-                    && app.view == RightView::NowPlaying
-                    && last_art_resend.elapsed() >= ART_RESEND
-                {
-                    last_art_resend = Instant::now();
-                    app.art_dirty = app.art_dirty.max(1);
+                if app.art_repaint != ArtRepaint::Idle {
                     dirty = true;
                 }
-                if app.art_dirty > 0 {
-                    dirty = true;
-                }
-                // Switching away and back drops the image data on the
-                // terminal's side; the placeholder cells alone then point at
-                // nothing and whatever the other view drew shows through.
                 if (app.view, app.zen) != last_layout {
                     last_layout = (app.view, app.zen);
-                    app.art_dirty = ART_REPAINTS;
+                    app.art_repaint = ArtRepaint::Wipe;
+                    dirty = true;
+                }
+                // An overlay draws over the art and the terminal loses those
+                // pixels, so the cover has to be sent again once it closes.
+                // Opening one must not wipe: the image would be redrawn a frame
+                // later, back on top of the popup.
+                let overlay = app.actions.is_some();
+                if overlay != overlay_open {
+                    overlay_open = overlay;
+                    if !overlay {
+                        app.art_repaint = ArtRepaint::Wipe;
+                    }
                     dirty = true;
                 }
                 if should_draw(dirty, animating, last_draw.elapsed()) {
                     advance_fade(&mut app);
-                    // Inline images are written once by ratatui; invalidate so
-                    // the re-encode produces a fresh cell.
-                    if app.art_dirty > 0 {
-                        app.art_dirty -= 1;
-                        if let Some(n) = app.now.as_mut() {
-                            if let Some(c) = n.cover.as_mut() {
-                                c.invalidate_cache();
-                            }
-                        }
-                    }
-                    terminal.draw(|f| render(f, &mut app))?;
+                    // Present the frame atomically. Without this the terminal
+                    // renders whatever has arrived so far, and a recolour that
+                    // touches every glyph on screen shows up half-applied.
+                    // Terminals that don't know the mode ignore it.
+                    let _ = execute!(io::stdout(), BeginSynchronizedUpdate);
+                    let drawn = terminal.draw(|f| render(f, &mut app));
+                    let _ = execute!(io::stdout(), EndSynchronizedUpdate);
+                    drawn?;
+                    app.art_repaint = app.art_repaint.advance();
                     last_draw = Instant::now();
                     dirty = false;
                 }
@@ -1306,13 +1321,13 @@ async fn run_ui(
                         }
                     }
                     // A repaint from the terminal's own buffer loses inline art.
-                    Ok(Event::Resize(..)) => app.art_dirty = ART_REPAINTS,
-                    // Focus is reported, so the timer has nothing left to cover.
-                    Ok(Event::FocusGained) => {
-                        art_resend = false;
-                        app.art_dirty = ART_REPAINTS;
+                    // A repaint from the terminal's own buffer loses inline art;
+                    // returning to the window is when it has to go back out.
+                    // tmux only forwards focus with `focus-events on` — see the
+                    // README — and stores sixel itself either way.
+                    Ok(Event::Resize(..)) | Ok(Event::FocusGained) => {
+                        app.art_repaint = ArtRepaint::Wipe;
                     }
-                    Ok(Event::FocusLost) => art_resend = false,
                     _ => {}
                 }
                 true
@@ -1582,6 +1597,13 @@ fn handle_key(
         return false;
     }
 
+    // Zen hides the library, so the keys that drive one do nothing rather than
+    // moving a selection nobody can see. Placed after the overlays above, which
+    // stay usable if one was already open when zen came on.
+    if app.zen && drives_library(code) {
+        return false;
+    }
+
     match code {
         KeyCode::Char('/') => {
             app.input_mode = true;
@@ -1659,7 +1681,17 @@ fn handle_key(
             app.status = format!("sorted by {}", m.label());
         }
         KeyCode::Char('a') => {
-            let item = app.cur_items().get(app.selected).cloned();
+            // Zen hides the library, so the menu belongs to what is playing —
+            // acting on a selection nobody can see is how it ends up offering
+            // "remove from Liked" for the wrong track.
+            let item = if app.zen {
+                app.now
+                    .as_ref()
+                    .filter(|n| !n.uri.is_empty())
+                    .map(|n| LibItem::track(n.title.clone(), n.artist.clone(), n.uri.clone()))
+            } else {
+                app.cur_items().get(app.selected).cloned()
+            };
             if let Some(item) = item {
                 if !item.is_header && !item.is_play {
                     // Instant menu (no network), then enrich when the API returns.
@@ -1694,10 +1726,8 @@ fn handle_key(
                 spawn_queue_fetch(app.webapi.clone(), queue_tx.clone());
             }
         }
-        KeyCode::Char('z') => {
-            app.zen = !app.zen;
-            app.art_dirty = ART_REPAINTS;
-        }
+        // The frame loop notices the layout change and wipes the art box.
+        KeyCode::Char('z') => app.zen = !app.zen,
         KeyCode::Down | KeyCode::Char('j') => app.move_sel(1),
         KeyCode::Up | KeyCode::Char('k') => app.move_sel(-1),
         // Needs a terminal that reports modified Enter (kitty, WezTerm, foot).
@@ -1733,6 +1763,24 @@ fn handle_key(
         _ => {}
     }
     false
+}
+
+/// Keys whose whole effect is on the library pane.
+///
+/// Zen hides that pane, so these do nothing there rather than moving a selection
+/// nobody can see — and `a` is deliberately absent, because it retargets onto
+/// the playing track instead of going quiet.
+fn drives_library(code: KeyCode) -> bool {
+    matches!(
+        code,
+        KeyCode::Tab
+            | KeyCode::BackTab
+            | KeyCode::Up
+            | KeyCode::Down
+            | KeyCode::Enter
+            | KeyCode::Esc
+            | KeyCode::Char('/' | '[' | ']' | 'j' | 'k' | 'o' | 'r' | 'P' | 'S')
+    )
 }
 
 fn consume_media_event<T>(event: Result<T, flume::RecvError>, open: &mut bool) -> Option<T> {
@@ -2387,6 +2435,19 @@ fn handle_engine_event(app: &mut App, ev: EngineEvent, meta_tx: &flume::Sender<T
                 let _ = controls.set_playback(playback);
             }
         }
+        EngineEvent::Reconnecting => {
+            app.status = "connection dropped — reconnecting…".to_string();
+        }
+        EngineEvent::Reconnected => {
+            // The replacement Connect device starts idle, so whatever was
+            // playing is not resumed; say so rather than leave a silent player
+            // looking broken.
+            app.status = if app.playback_started {
+                "reconnected — press play to resume".to_string()
+            } else {
+                "reconnected".to_string()
+            };
+        }
         EngineEvent::EndOfTrack { .. } => {}
     }
 }
@@ -2418,8 +2479,9 @@ fn apply_meta(
         .image
         .as_ref()
         .map(|img| Cover::from_image(img.clone(), app.picker.clone()));
-    // New art to transmit — see ART_REPAINTS.
-    app.art_dirty = ART_REPAINTS;
+    // A different cover encodes to a different symbol, so the diff emits it on
+    // its own — no wipe, which would flash a blank box between the two covers.
+    app.art_repaint = ArtRepaint::Draw;
     app.status.clear();
     app.lyrics.clear();
     app.lyrics_synced = false;
@@ -3345,15 +3407,27 @@ fn fetch_playback_state(token: &str) -> Option<PlaybackState> {
 
 /// Transfer the current server-side playback onto the myx device (with its full
 /// context + queue + position). `play=false` transfers paused.
-fn transfer_playback(token: &str, device_id: &str, play: bool) -> bool {
+/// `Ok(())` on success, `Err(reason)` with something worth showing otherwise.
+fn transfer_playback(token: &str, device_id: &str, play: bool) -> Result<(), String> {
     let client = http_client();
-    client
+    match client
         .put(format!("{API}/me/player"))
         .bearer_auth(token)
         .json(&serde_json::json!({ "device_ids": [device_id], "play": play }))
         .send()
-        .map(|r| r.status().is_success())
-        .unwrap_or(false)
+    {
+        Ok(r) if r.status().is_success() => Ok(()),
+        Ok(r) => {
+            let code = r.status().as_u16();
+            let body = r.text().unwrap_or_default();
+            liblog(format!("transfer -> HTTP {code}: {body}"));
+            Err(format!("HTTP {code}"))
+        }
+        Err(e) => {
+            liblog(format!("transfer failed: {e}"));
+            Err("network error".to_string())
+        }
+    }
 }
 
 /// Boot restore: read the live playback state, transfer it onto myx (retrying
@@ -3368,7 +3442,7 @@ fn spawn_restore(webapi: Arc<Mutex<WebApi>>, device_id: String, tx: flume::Sende
         };
         // Retry the transfer — the Connect device can take a moment to appear.
         for _ in 0..6 {
-            if transfer_playback(&token, &device_id, false) {
+            if transfer_playback(&token, &device_id, false).is_ok() {
                 break;
             }
             std::thread::sleep(Duration::from_secs(1));
@@ -3478,6 +3552,51 @@ fn render(f: &mut Frame, app: &mut App) {
 
     if app.actions.is_some() {
         render_actions_overlay(f, app, theme, area);
+    }
+}
+
+/// Blank `area` and force it out to the terminal, erasing an inline image.
+///
+/// `ratatui-image` marks the image's cells `Skip` without changing their
+/// symbols, and a blank cell compares equal to the blank that was already there
+/// — so an ordinary `Clear` writes nothing and the picture survives it.
+/// `AlwaysUpdate` is what makes the diff emit them anyway.
+fn wipe_area(f: &mut Frame, area: Rect) {
+    let buf = f.buffer_mut();
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            if let Some(cell) = buf.cell_mut((x, y)) {
+                cell.reset();
+                cell.set_diff_option(CellDiffOption::AlwaysUpdate);
+            }
+        }
+    }
+}
+
+/// Keep the terminal's own pixels in `area` by telling the diff to leave those
+/// cells alone — what `ratatui-image` does for the image it just drew, without
+/// drawing it again.
+fn hold_area(f: &mut Frame, area: Rect) {
+    let buf = f.buffer_mut();
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            if let Some(cell) = buf.cell_mut((x, y)) {
+                cell.set_diff_option(CellDiffOption::Skip);
+            }
+        }
+    }
+}
+
+/// Force whatever is already in `area` out to the terminal, so an overlay lands
+/// on top of an inline image instead of being skipped over it.
+fn force_area(f: &mut Frame, area: Rect) {
+    let buf = f.buffer_mut();
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            if let Some(cell) = buf.cell_mut((x, y)) {
+                cell.set_diff_option(CellDiffOption::AlwaysUpdate);
+            }
+        }
     }
 }
 
@@ -3798,11 +3917,20 @@ fn render_nowplaying_view(f: &mut Frame, app: &mut App, theme: Theme, area: Rect
         height: art_h,
     };
 
+    let repaint = app.art_repaint;
     match app.now.as_mut().and_then(|n| n.cover.as_mut()) {
-        Some(cover) => cover.render(f, art_rect),
-        // No art to draw over the cells another view left behind. They are only
-        // ever written by the image widget, so wipe them explicitly.
-        None => f.render_widget(Clear, art_rect),
+        _ if repaint == ArtRepaint::Wipe => wipe_area(f, art_rect),
+        // Writing the escape means transmitting the image, so only do it when
+        // something actually asked for it. A theme fade repaints every glyph on
+        // screen dozens of times, and re-sending the cover on each of those is
+        // what made it flicker.
+        Some(cover) if repaint == ArtRepaint::Draw || cover.needs_send(art_rect) => {
+            cover.render(f, art_rect)
+        }
+        // Already on screen: hold the cells so nothing overwrites the picture,
+        // and send nothing.
+        Some(_) => hold_area(f, art_rect),
+        None => wipe_area(f, art_rect),
     }
 
     if let Some(n) = app.now.as_ref() {
@@ -3852,7 +3980,8 @@ fn center_v(area: Rect, height: u16) -> Rect {
 fn render_now_strip(f: &mut Frame, app: &mut App, theme: Theme, area: Rect) {
     let rows = Layout::vertical([Constraint::Length(1), Constraint::Length(1)]).split(area);
 
-    // Volume meter (top row, far right).
+    // Volume meter (top row, far right). Still honest in remote mode: +/- goes
+    // to the remote device's volume.
     render_volume(f, app, theme, rows[0]);
 
     // Seek/progress bar (bottom row). Record bar geometry for click-to-seek.
@@ -4121,45 +4250,49 @@ fn render_footer(f: &mut Frame, app: &App, theme: Theme, area: Rect) {
     let key = |k: &'static str| Span::styled(k, Style::default().fg(theme.primary.into()));
     let lbl = |t: &'static str| Span::styled(t, theme.muted());
     let enter_lbl = enter_label(app.cur_items().get(app.selected));
-    let line = Line::from(vec![
-        key("⇥"),
-        lbl(" section   "),
-        key("←→"),
-        lbl(" view   "),
-        key("/"),
-        lbl(" search   "),
-        key("⏎"),
-        Span::styled(format!(" {enter_lbl}   "), theme.muted()),
-        key("⇧⏎"),
-        lbl(" play   "),
-        key("S"),
-        lbl(" shuffle   "),
-        key("␣"),
-        Span::styled(
-            if app.now.as_ref().is_some_and(|n| n.is_playing) {
-                " pause   "
-            } else {
-                " play    "
-            },
-            theme.muted(),
+    let play_lbl = if app.now.as_ref().is_some_and(|n| n.is_playing) {
+        " pause   "
+    } else {
+        " play    "
+    };
+    // Flagged hints go with the library pane, which zen hides — a key that does
+    // nothing must not be advertised.
+    let hints = [
+        (true, key("⇥"), lbl(" section   ")),
+        (false, key("←→"), lbl(" view   ")),
+        (true, key("/"), lbl(" search   ")),
+        (
+            true,
+            key("⏎"),
+            Span::styled(format!(" {enter_lbl}   "), theme.muted()),
         ),
-        key("n/b"),
-        lbl(" skip   "),
-        key("⇧←→"),
-        lbl(" seek   "),
-        key("o"),
-        lbl(" sort   "),
-        key("+/-"),
-        lbl(" vol   "),
-        Span::styled("s", Style::default().fg(on(app.shuffle).into())),
-        lbl(" shuffle   "),
-        key("a"),
-        lbl(" actions   "),
-        Span::styled("z", Style::default().fg(on(app.zen).into())),
-        lbl(" zen   "),
-        key("q"),
-        lbl(" quit"),
-    ]);
+        (true, key("⇧⏎"), lbl(" play   ")),
+        (true, key("S"), lbl(" shuffle   ")),
+        (false, key("␣"), Span::styled(play_lbl, theme.muted())),
+        (false, key("n/b"), lbl(" skip   ")),
+        (false, key("⇧←→"), lbl(" seek   ")),
+        (true, key("o"), lbl(" sort   ")),
+        (false, key("+/-"), lbl(" vol   ")),
+        (
+            false,
+            Span::styled("s", Style::default().fg(on(app.shuffle).into())),
+            lbl(" shuffle   "),
+        ),
+        (false, key("a"), lbl(" actions   ")),
+        (
+            false,
+            Span::styled("z", Style::default().fg(on(app.zen).into())),
+            lbl(" zen   "),
+        ),
+        (false, key("q"), lbl(" quit")),
+    ];
+    let line = Line::from(
+        hints
+            .into_iter()
+            .filter(|(needs_library, ..)| !needs_library || !app.zen)
+            .flat_map(|(_, k, label)| [k, label])
+            .collect::<Vec<_>>(),
+    );
     f.render_widget(Paragraph::new(line).alignment(Alignment::Center), area);
 }
 
@@ -4209,6 +4342,7 @@ fn render_actions_overlay(f: &mut Frame, app: &App, theme: Theme, area: Rect) {
         }
     }
     f.render_widget(Paragraph::new(lines), inner);
+    force_area(f, rect);
 }
 
 fn render_queue_view(f: &mut Frame, app: &App, theme: Theme, area: Rect) {
@@ -4857,6 +4991,54 @@ mod nav_tests {
         assert_eq!(scrub_target(0, 0, -5_000), 0);
     }
 
+    // -------------------------------------------------------- drives_library
+
+    #[test]
+    fn zen_ignores_the_keys_that_only_move_the_hidden_library() {
+        for code in [
+            KeyCode::Tab,
+            KeyCode::BackTab,
+            KeyCode::Up,
+            KeyCode::Down,
+            KeyCode::Enter,
+            KeyCode::Char('j'),
+            KeyCode::Char('/'),
+            KeyCode::Char('o'),
+        ] {
+            assert!(drives_library(code), "{code:?} only drives the library");
+        }
+    }
+
+    #[test]
+    fn zen_keeps_playback_and_the_right_hand_pane() {
+        for code in [
+            KeyCode::Char(' '),
+            KeyCode::Char('n'),
+            KeyCode::Char('b'),
+            KeyCode::Char('s'),
+            KeyCode::Char('z'),
+            KeyCode::Char('q'),
+            KeyCode::Left,
+            KeyCode::Right,
+            // Retargets onto the playing track rather than going quiet.
+            KeyCode::Char('a'),
+        ] {
+            assert!(!drives_library(code), "{code:?} must still work in zen");
+        }
+    }
+
+    // ---------------------------------------------------------- ArtRepaint
+
+    #[test]
+    fn a_forced_repaint_blanks_the_box_before_redrawing_it() {
+        // The wipe is the whole mechanism: re-encoding is byte-identical for
+        // sixel and iTerm2, so a blank frame is the only thing the diff will
+        // emit — and it takes the overlay's leftovers with it.
+        assert_eq!(ArtRepaint::Wipe.advance(), ArtRepaint::Draw);
+        assert_eq!(ArtRepaint::Draw.advance(), ArtRepaint::Idle);
+        assert_eq!(ArtRepaint::Idle.advance(), ArtRepaint::Idle);
+    }
+
     // ----------------------------------------------------------- should_draw
 
     #[test]
@@ -4881,6 +5063,14 @@ mod nav_tests {
     fn animation_redraws_between_the_two() {
         assert!(should_draw(false, true, ANIM_FRAME));
         assert!(!should_draw(false, true, MIN_FRAME));
+    }
+
+    #[test]
+    fn a_fade_is_long_enough_to_be_smooth_at_the_animation_rate() {
+        // Smoothness has to come from duration, not frame rate: every present
+        // recomposes the viewport and the inline cover shimmers at 60fps.
+        let steps = FADE_MS / ANIM_FRAME.as_millis() as u64;
+        assert!(steps >= 30, "only {steps} steps of recolour");
     }
 }
 

--- a/src/reactive.rs
+++ b/src/reactive.rs
@@ -42,10 +42,25 @@ fn nearest_hue(swatches: &[Rgb], target_hue: f32, max_dist: f32) -> Option<Rgb> 
         .map(|(c, _)| for_dark_fg(c))
 }
 
+/// How saturated the palette's most colourful swatch must be for the surface to
+/// take its full tint. Below this the UI slides toward neutral, which is what a
+/// black-and-white cover should actually look like.
+const FULL_TINT_AT: f32 = 0.35;
+
 fn theme_from_swatches(swatches: &[Rgb], name: &'static str) -> Theme {
-    // Dominant swatch (color-thief returns it first) → base hue for the surface.
-    let dominant = swatches[0];
-    let base_hue = rgb_to_hsl(dominant).h;
+    // The dominant swatch is usually the surface hue, but a white or black cover
+    // has no hue at all — `rgb_to_hsl` reports 0 for grey, and 0 is red. Take the
+    // hue from the most saturated swatch that has one instead.
+    let hue_src = swatches
+        .iter()
+        .copied()
+        .max_by(|&a, &b| rgb_to_hsl(a).s.total_cmp(&rgb_to_hsl(b).s))
+        .unwrap_or(swatches[0]);
+    let base_hue = rgb_to_hsl(hue_src).h;
+    // ...and if even that swatch is grey, tint nothing: the art has no colour to
+    // borrow, so the UI stays neutral rather than picking one at random.
+    let tint_strength = (rgb_to_hsl(hue_src).s / FULL_TINT_AT).clamp(0.0, 1.0);
+    let surface = |s: f32, l: f32| color::tint(base_hue, s * tint_strength, l);
 
     // Rank by vibrance for the accent selection.
     let mut ranked: Vec<Rgb> = swatches.to_vec();
@@ -92,16 +107,70 @@ fn theme_from_swatches(swatches: &[Rgb], name: &'static str) -> Theme {
         warning,
         success,
         info,
-        text: color::tint(base_hue, 0.14, 0.93),
-        text_muted: color::tint(base_hue, 0.13, 0.58),
+        text: surface(0.14, 0.93),
+        text_muted: surface(0.13, 0.58),
         // Three background layers, all sharing the album's hue at rising lightness.
-        background: color::tint(base_hue, 0.28, 0.075),
-        background_panel: color::tint(base_hue, 0.26, 0.11),
-        background_element: color::tint(base_hue, 0.22, 0.16),
+        background: surface(0.28, 0.075),
+        background_panel: surface(0.26, 0.11),
+        background_element: surface(0.22, 0.16),
         // Border shades: subtle chrome that still belongs to the palette.
-        border: color::tint(base_hue, 0.16, 0.34),
+        border: surface(0.16, 0.34),
         border_active: primary,
-        border_subtle: color::tint(base_hue, 0.16, 0.24),
-        border_dimmest: color::tint(base_hue, 0.18, 0.17),
+        border_subtle: surface(0.16, 0.24),
+        border_dimmest: surface(0.18, 0.17),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::hue_distance;
+
+    #[test]
+    fn a_greyscale_cover_does_not_come_out_red() {
+        // `rgb_to_hsl` reports hue 0 for every grey, and hue 0 is red — which is
+        // how a black-and-white cover used to tint the whole UI burgundy.
+        let greys = [
+            Rgb::new(250, 250, 250),
+            Rgb::new(18, 18, 18),
+            Rgb::new(128, 128, 130),
+        ];
+        let theme = theme_from_swatches(&greys, "grey");
+        for (what, c) in [
+            ("background", theme.background),
+            ("text", theme.text),
+            ("border", theme.border),
+            ("primary", theme.primary),
+        ] {
+            let s = rgb_to_hsl(c).s;
+            assert!(s < 0.15, "{what} invented a hue: saturation {s}");
+        }
+    }
+
+    #[test]
+    fn a_colourful_cover_keeps_its_hue() {
+        let blues = [
+            Rgb::new(30, 60, 200),
+            Rgb::new(20, 40, 160),
+            Rgb::new(60, 90, 220),
+        ];
+        let theme = theme_from_swatches(&blues, "blue");
+        let bg = rgb_to_hsl(theme.background);
+        assert!(bg.s > 0.15, "colourful art lost its tint: {}", bg.s);
+        assert!(hue_distance(bg.h, 225.0) < 45.0, "hue drifted to {}", bg.h);
+    }
+
+    #[test]
+    fn a_mostly_white_cover_borrows_the_one_colour_it_has() {
+        // A white sleeve with a small coloured mark should take that mark's hue,
+        // not the hue of the white that dominates it.
+        let mostly_white = [
+            Rgb::new(252, 252, 250),
+            Rgb::new(240, 240, 238),
+            Rgb::new(40, 150, 90),
+        ];
+        let theme = theme_from_swatches(&mostly_white, "white");
+        let bg = rgb_to_hsl(theme.background);
+        assert!(hue_distance(bg.h, 150.0) < 45.0, "hue is {}", bg.h);
     }
 }


### PR DESCRIPTION
- Draw when something changed instead of on a timer: input redraws within one 16ms refresh, animation at 30fps, an untouched screen at 2fps instead of 60 — a held arrow key waited up to 100ms per step, which is what made scrolling look torn
- Move the queue refresh and state save off the frame counter onto a timer; at 60fps they fired every four seconds, burning API quota and disk writes
- Cache catalogue reads and album art under ~/.cache/myx/api, serving a stale entry when a request fails — a spent development-mode quota is exactly when an artist page would otherwise come up empty
- Never cache a failed cover request: image entries never expire, so an error body would mean a permanently broken cover
- Draw sixel, unwrapped, where tmux reports sixel support; it is the only image protocol tmux parses and repaints from its own buffer, so kitty and iTerm2 ride through as passthrough and are gone on the next repaint
- Blank and overdraw the art with CellDiffOption::AlwaysUpdate; ratatui-image marks the image's cells Skip without changing their symbols, and a blank cell compares equal to the blank already there, so Clear over an image wrote nothing and the picture survived every attempt to erase it
- Draw overlays on top of the cover instead of under it — the actions menu used to leave its right-hand half stencilled across the art with the image gone
- Write the image escape only when the cover changes; it went out on every frame, so a recolour that repaints the screen dozens of times in a row made the cover flicker
- Rebuild the session, player and Connect device when the access point stops answering; librespot invalidates the session on a keep-alive timeout and leaves recovery to the caller (session.rs: "TODO: Optionally reconnect"), so every command afterwards failed with Internal error { channel closed } until a restart
- Send Activate ahead of every transport command, since Spotify drops an idle paused device out of the Connect cluster and librespot then discards everything else with "will be ignored while Not Active" — the phone's pause button greyed out because the state we kept publishing read as paused
- Keep volume out of that path so a volume key can never yank playback off whatever device actually holds it
- Route the next play through a fresh load after a forced stop; librespot clears its context in handle_disconnect, and handle_play returns early on Stopped, so a bare play could never resume from there
- Emit position corrections once a second instead of ten times, since each one pushes the whole Connect state to Spotify and the position is extrapolated locally anyway
- Forward librespot's own log into ~/.cache/myx/myx.log under MYX_LOG, at info by default — its "device became inactive" line is the only account of the failure above, and at warn the log showed only the fallout
- Take the theme's base hue from the most saturated swatch, not the dominant one; rgb_to_hsl reports hue 0 for every grey and hue 0 is red, so black-and-white covers all painted the UI the same burgundy
- Scale the surface tint by how colourful the art is, so greyscale art gets a neutral UI, and stop for_dark_fg raising saturation on an achromatic swatch
- Present each frame atomically with synchronized output (DECSET 2026); a track change recolours every glyph at once and the terminal rendered that half-applied
- Run the theme cross-fade over 1800ms — smoothness comes from duration, since every present recomposes the viewport
- Give WezTerm and Warp iTerm2 images: both answer the kitty query but neither places unicode placeholders, which is how ratatui-image draws kitty, so the cover came out as a see-through hole
- Honour protocol and MYX_PROTOCOL inside a sixel-capable tmux; the sixel picker drops tmux passthrough, so a forced kitty or iTerm2 left its escapes for tmux to eat
- Detect kitty from the client tmux has attached now instead of KITTY_WINDOW_ID, which lingers in a session's environment after reattaching from another terminal
- Build the picker before the tokio runtime and the player exist — picking sixel swaps TERM around the query, and setenv is only safe without concurrent readers
- Ignore the keys that only drive the hidden library in zen mode and drop their footer hints; a retargets onto the playing track rather than the invisible selection
- Write ~/.config/myx/config.toml on first run with every key commented out, and add a protocol key (kitty, iterm2, sixel, halfblocks) for when detection picks wrong
- Give each cache write a unique temp name so two threads fetching the same URL can't interleave into one corrupt entry
