### PR TITLE
feat(search): real cursor editing via tui-textarea-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,6 +2822,7 @@ dependencies = [
  "souvlaki",
  "tokio",
  "toml",
+ "tui-textarea-2",
  "vergen",
  "windows-win",
  "winit",
@@ -5769,6 +5770,20 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
+name = "tui-textarea-2"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4296a13cbcb20abd7b62f96154cad81053eb82ee8d24db3d7fdca16b31f118e9"
+dependencies = [
+ "crossterm",
+ "portable-atomic",
+ "ratatui-core",
+ "ratatui-widgets",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default-run = "myx"
 ratatui = "0.30.2"
 crossterm = "0.29.0"
 ratatui-image = { version = "11.0.6", default-features = false, features = ["crossterm"] }
+tui-textarea-2 = { version = "0.12", default-features = false, features = ["crossterm"] }
 image = "0.25"
 color-thief = "0.2"
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -74,9 +74,23 @@ pub(crate) struct BrowseState {
 /// query, and the results that temporarily replace the library list.
 pub(crate) struct SearchState {
     pub(crate) input_mode: bool,
-    pub(crate) query: String,
+    // The prompt's editor. Read through `query()`, reset through `clear()`.
+    pub(crate) input: tui_textarea::TextArea<'static>,
     pub(crate) searching: bool,
     pub(crate) search_results: Vec<LibItem>,
+}
+
+impl SearchState {
+    /// The typed query. First line only — the prompt is single-line (Enter is
+    /// intercepted), so this also defuses any newline a paste might smuggle in.
+    pub(crate) fn query(&self) -> &str {
+        self.input.lines().first().map_or("", String::as_str)
+    }
+
+    /// Empty the editor (fresh buffer, cursor at column 0).
+    pub(crate) fn clear(&mut self) {
+        self.input = tui_textarea::TextArea::default();
+    }
 }
 
 /// What the user is looking at: the right pane's mode, the zen (sidebar

--- a/src/input/key.rs
+++ b/src/input/key.rs
@@ -37,7 +37,7 @@ pub(crate) fn handle_key(
             KeyCode::Esc => app.search.input_mode = false,
             KeyCode::Enter => {
                 app.search.input_mode = false;
-                let q = app.search.query.trim().to_string();
+                let q = app.search.query().trim().to_string();
                 if !q.is_empty() {
                     app.search.searching = true;
                     app.browse.selected = 0;
@@ -45,11 +45,13 @@ pub(crate) fn handle_key(
                     spawn_search(app.svc.webapi.clone(), q, chans.search.clone());
                 }
             }
-            KeyCode::Backspace => {
-                app.search.query.pop();
+            // Everything else — typing, cursor movement, word ops — is the
+            // editor's business. Enter is intercepted above, so no newlines.
+            _ => {
+                app.search
+                    .input
+                    .input(crossterm::event::KeyEvent::new(code, mods));
             }
-            KeyCode::Char(c) => app.search.query.push(c),
-            _ => {}
         }
         return false;
     }
@@ -64,7 +66,7 @@ pub(crate) fn handle_key(
     match code {
         KeyCode::Char('/') => {
             app.search.input_mode = true;
-            app.search.query.clear();
+            app.search.clear();
         }
         KeyCode::Char('q') => return true,
         KeyCode::Esc => {

--- a/src/input/key.rs
+++ b/src/input/key.rs
@@ -45,6 +45,11 @@ pub(crate) fn handle_key(
                     spawn_search(app.svc.webapi.clone(), q, chans.search.clone());
                 }
             }
+            // Ctrl-U clears the query — readline muscle memory. The fork
+            // binds Ctrl-U to undo; shadow it (same call as agent-runtime).
+            KeyCode::Char('u') if mods.contains(crossterm::event::KeyModifiers::CONTROL) => {
+                app.search.clear();
+            }
             // Everything else — typing, cursor movement, word ops — is the
             // editor's business. Enter is intercepted above, so no newlines.
             _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,7 +332,7 @@ async fn boot(
         },
         search: SearchState {
             input_mode: false,
-            query: String::new(),
+            input: Default::default(),
             searching: false,
             search_results: Vec::new(),
         },

--- a/src/main_tests/mod.rs
+++ b/src/main_tests/mod.rs
@@ -3,6 +3,7 @@
 
 mod nav;
 mod playlist;
+mod search;
 
 /// Live-API tests, `#[ignore]`d so `cargo test` stays offline:
 ///

--- a/src/main_tests/search.rs
+++ b/src/main_tests/search.rs
@@ -1,0 +1,126 @@
+//! The `/` search prompt: the tui-textarea editor behind it and the cursor
+//! glyph placement in the header line.
+
+use crate::ui::split_at_cursor;
+use crate::*;
+use crossterm::event::KeyEvent;
+
+fn state() -> SearchState {
+    SearchState {
+        input_mode: true,
+        input: Default::default(),
+        searching: false,
+        search_results: Vec::new(),
+    }
+}
+
+fn key(s: &mut SearchState, code: KeyCode, mods: KeyModifiers) {
+    s.input.input(KeyEvent::new(code, mods));
+}
+
+fn type_str(s: &mut SearchState, text: &str) {
+    for c in text.chars() {
+        key(s, KeyCode::Char(c), KeyModifiers::empty());
+    }
+}
+
+// -------------------------------------------------------------- editing
+
+#[test]
+fn typing_updates_the_query() {
+    let mut s = state();
+    type_str(&mut s, "radiohead");
+    assert_eq!(s.query(), "radiohead");
+    assert_eq!(s.input.cursor(), (0, 9));
+}
+
+#[test]
+fn left_arrow_then_typing_inserts_mid_string() {
+    let mut s = state();
+    type_str(&mut s, "abd");
+    key(&mut s, KeyCode::Left, KeyModifiers::empty());
+    type_str(&mut s, "c");
+    assert_eq!(s.query(), "abcd");
+    assert_eq!(s.input.cursor(), (0, 3), "cursor sits after the insert");
+}
+
+#[test]
+fn ctrl_w_deletes_the_word_before_the_cursor() {
+    let mut s = state();
+    type_str(&mut s, "boards of canada");
+    key(&mut s, KeyCode::Char('w'), KeyModifiers::CONTROL);
+    assert_eq!(s.query(), "boards of ");
+}
+
+#[test]
+fn backspace_still_deletes() {
+    let mut s = state();
+    type_str(&mut s, "ab");
+    key(&mut s, KeyCode::Backspace, KeyModifiers::empty());
+    assert_eq!(s.query(), "a");
+}
+
+// ---------------------------------------------------------- prompt contract
+
+#[test]
+fn esc_preserves_the_query_content() {
+    // key.rs intercepts Esc (exit input mode) without touching the editor —
+    // the buffer only resets on the next `/`. Mirror that sequence here.
+    let mut s = state();
+    type_str(&mut s, "aphex twin");
+    s.input_mode = false; // the Esc branch, minus the App plumbing
+    assert_eq!(s.query(), "aphex twin");
+    s.clear(); // the `/` branch
+    assert_eq!(s.query(), "");
+    assert_eq!(s.input.cursor(), (0, 0));
+}
+
+#[test]
+fn enter_submits_the_trimmed_query() {
+    // key.rs intercepts Enter and reads `query().trim()` — no newline ever
+    // reaches the editor.
+    let mut s = state();
+    type_str(&mut s, "  ok computer  ");
+    assert_eq!(s.query().trim(), "ok computer");
+}
+
+#[test]
+fn a_pasted_newline_cannot_leak_past_the_accessor() {
+    let mut s = state();
+    s.input.insert_str("first\nsecond");
+    assert_eq!(s.query(), "first", "query() is first-line only");
+}
+
+// ------------------------------------------------------------ cursor glyph
+
+#[test]
+fn the_cursor_glyph_splits_mid_string() {
+    assert_eq!(split_at_cursor("abcd", 2), ("ab", "cd"));
+}
+
+#[test]
+fn the_cursor_glyph_lands_at_the_ends() {
+    assert_eq!(split_at_cursor("abcd", 0), ("", "abcd"));
+    assert_eq!(split_at_cursor("abcd", 4), ("abcd", ""));
+    assert_eq!(split_at_cursor("", 0), ("", ""));
+}
+
+#[test]
+fn the_cursor_glyph_clamps_past_the_end() {
+    assert_eq!(split_at_cursor("ab", 99), ("ab", ""));
+}
+
+#[test]
+fn the_cursor_glyph_splits_on_char_boundaries() {
+    // col is a char index, not bytes — multibyte text must not panic.
+    assert_eq!(split_at_cursor("héllo", 2), ("hé", "llo"));
+}
+
+#[test]
+fn the_glyph_follows_real_editing() {
+    let mut s = state();
+    type_str(&mut s, "abd");
+    key(&mut s, KeyCode::Left, KeyModifiers::empty());
+    let (before, after) = split_at_cursor(s.query(), s.input.cursor().1);
+    assert_eq!((before, after), ("ab", "d"));
+}

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -241,10 +241,6 @@ pub(crate) fn render_library(
 /// Split the query at the editor's cursor column (a char index) so the ▏
 /// glyph can be drawn where the cursor actually is. Clamps past-the-end.
 pub(crate) fn split_at_cursor(q: &str, col: usize) -> (&str, &str) {
-    let byte = q
-        .char_indices()
-        .nth(col)
-        .map(|(i, _)| i)
-        .unwrap_or(q.len());
+    let byte = q.char_indices().nth(col).map(|(i, _)| i).unwrap_or(q.len());
     q.split_at(byte)
 }

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -27,10 +27,11 @@ pub(crate) fn render_library(
             Span::styled("  Esc", theme.muted()),
         ])
     } else if app.search.input_mode {
+        let (before, after) = split_at_cursor(app.search.query(), app.search.input.cursor().1);
         Line::from(vec![
             Span::styled("search: ", theme.heading()),
             Span::styled(
-                format!("{}▏", app.search.query),
+                format!("{before}▏{after}"),
                 Style::default().fg(theme.text.into()),
             ),
         ])
@@ -38,7 +39,7 @@ pub(crate) fn render_library(
         Line::from(vec![
             Span::styled("search: ", theme.heading()),
             Span::styled(
-                app.search.query.clone(),
+                app.search.query().to_string(),
                 Style::default().fg(theme.text.into()),
             ),
             Span::styled("  (Esc)", theme.muted()),
@@ -235,4 +236,15 @@ pub(crate) fn render_library(
     } else {
         out.hits.scroll = None;
     }
+}
+
+/// Split the query at the editor's cursor column (a char index) so the ▏
+/// glyph can be drawn where the cursor actually is. Clamps past-the-end.
+pub(crate) fn split_at_cursor(q: &str, col: usize) -> (&str, &str) {
+    let byte = q
+        .char_indices()
+        .nth(col)
+        .map(|(i, _)| i)
+        .unwrap_or(q.len());
+    q.split_at(byte)
 }


### PR DESCRIPTION
Closes #28.

## What

Replaces the hand-rolled search input (`query.push(c)` / `query.pop()` — no cursor, no movement) with `tui-textarea-2` as the editing state machine.

Search now supports: cursor movement (←/→, Home/End), mid-string insertion, word ops (Ctrl-W delete-word, Alt-b/f), undo/redo (Ctrl-Z / Ctrl-R), and unicode-correct editing. The `▏` cursor glyph now renders at the **real** cursor column instead of being appended at the end.

## Design

- `SearchState.query: String` → `input: TextArea<'static>`; consumers read through `query()` (first-line-only — defuses any pasted newlines) and `clear()`
- `input_mode` key handling: Esc / Enter / Ctrl-U intercepted (submit contract unchanged, trimmed query, same `spawn_search` path); everything else forwards to the editor
- **Ctrl-U clears the query** — shadows the fork's default Ctrl-U=undo bind, keeping readline muscle memory (same decision as agent-runtime's adoption)
- Render: pure `split_at_cursor` fn places `▏` (char-indexed, clamped, boundary-safe); the post-submit "searching" header variant preserved exactly
- Dependency: `tui-textarea-2 = "0.12"` (`default-features = false, features = ["crossterm"]`) — maintained fork, matches our ratatui 0.30.2 / crossterm 0.29 pins, no new transitive deps

## Testing

- 12 new unit tests: typing, mid-string insert, Ctrl-W, Backspace, Esc-preserves/`/`-clears contract, trimmed submit, pasted-newline containment, glyph placement (ends/clamp/multibyte/live)
- Suite: 51 passed / 0 failed; clippy `-D warnings` clean
- Manual QA on the release binary: mid-string insert, word delete, Ctrl-U clear — verified live
