### PR TITLE
feat(ui): loading states for undelivered sections and in-flight searches

### DIFF
--- a/src/app/library.rs
+++ b/src/app/library.rs
@@ -24,7 +24,7 @@ impl RightView {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum Section {
     Home,
     Recent,
@@ -186,6 +186,11 @@ pub(crate) struct Library {
     pub(crate) liked: Vec<LibItem>,
     pub(crate) albums: Vec<LibItem>,
     pub(crate) artists: Vec<LibItem>,
+    // Sections that have received a delivery since boot / the last refresh.
+    // An undelivered section is *loading*, not empty — the UI renders the
+    // difference (issue #25). Lives here because `set` is the one delivery
+    // point for every section.
+    loaded: std::collections::HashSet<Section>,
 }
 
 impl Library {
@@ -210,6 +215,7 @@ impl Library {
         }
     }
     pub(crate) fn set(&mut self, s: Section, items: Vec<LibItem>) {
+        self.loaded.insert(s);
         match s {
             Section::Home => self.home = items,
             Section::Recent => self.recent = items,
@@ -217,6 +223,50 @@ impl Library {
             Section::Liked => self.liked = items,
             Section::Albums => self.albums = items,
             Section::Artists => self.artists = items,
+        }
+    }
+
+    /// Has this section received a delivery since boot / the last refresh?
+    pub(crate) fn is_loaded(&self, s: Section) -> bool {
+        self.loaded.contains(&s)
+    }
+
+    /// A refresh is starting: sections are loading again. Existing items keep
+    /// rendering; only *empty* sections fall back to the loading label.
+    pub(crate) fn reset_loading(&mut self) {
+        self.loaded.clear();
+    }
+
+    /// The fetch gave up (retries exhausted). Mark everything delivered so
+    /// empty sections read "(empty)" honestly — the status line carries the
+    /// failure message.
+    pub(crate) fn mark_all_loaded(&mut self) {
+        self.loaded.extend(Section::ALL);
+    }
+}
+
+#[cfg(test)]
+mod loaded_tracking_tests {
+    use super::*;
+
+    #[test]
+    fn sections_start_unloaded_and_load_on_delivery() {
+        let mut lib = Library::default();
+        assert!(!lib.is_loaded(Section::Liked));
+        lib.set(Section::Liked, Vec::new()); // empty delivery still counts
+        assert!(lib.is_loaded(Section::Liked));
+        assert!(!lib.is_loaded(Section::Albums)); // others untouched
+    }
+
+    #[test]
+    fn refresh_resets_and_failure_marks_all() {
+        let mut lib = Library::default();
+        lib.set(Section::Home, Vec::new());
+        lib.reset_loading();
+        assert!(!lib.is_loaded(Section::Home));
+        lib.mark_all_loaded();
+        for s in Section::ALL {
+            assert!(lib.is_loaded(s));
         }
     }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -77,6 +77,10 @@ pub(crate) struct SearchState {
     // The prompt's editor. Read through `query()`, reset through `clear()`.
     pub(crate) input: tui_textarea::TextArea<'static>,
     pub(crate) searching: bool,
+    // A submitted query whose results have not landed yet. `searching` means
+    // "the search view is active"; this means "the wire is hot" — the empty
+    // list renders "searching…" instead of "(empty)" while it's set.
+    pub(crate) in_flight: bool,
     pub(crate) search_results: Vec<LibItem>,
 }
 

--- a/src/input/key.rs
+++ b/src/input/key.rs
@@ -40,6 +40,7 @@ pub(crate) fn handle_key(
                 let q = app.search.query().trim().to_string();
                 if !q.is_empty() {
                     app.search.searching = true;
+                    app.search.in_flight = true;
                     app.browse.selected = 0;
                     app.status = "searching…".to_string();
                     spawn_search(app.svc.webapi.clone(), q, chans.search.clone());
@@ -135,6 +136,7 @@ pub(crate) fn handle_key(
         }
         KeyCode::Char('r') => {
             app.status = "loading library…".to_string();
+            app.browse.library.reset_loading();
             spawn_library_fetch(
                 app.svc.webapi.clone(),
                 chans.lib.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,6 +334,7 @@ async fn boot(
             input_mode: false,
             input: Default::default(),
             searching: false,
+            in_flight: false,
             search_results: Vec::new(),
         },
         view: ViewState {
@@ -512,6 +513,9 @@ async fn run_ui(
                         spawn_library_fetch(app.svc.webapi.clone(), chans.lib.clone(), chans.libdone.clone());
                     } else {
                         app.status = "library failed — press r to reload".to_string();
+                        // Give up honestly: undelivered sections stop claiming
+                        // "loading…" — the status line carries the failure.
+                        app.browse.library.mark_all_loaded();
                     }
                 }
                 // Radio results are drained here (not as a `select!` arm) for the
@@ -656,6 +660,7 @@ async fn run_ui(
             }
             s = search_rx.recv_async() => {
                 if let Ok(results) = s {
+                    app.search.in_flight = false;
                     app.search.search_results = results;
                     app.browse.selected = app.first_selectable();
                     app.status = if app.search.search_results.is_empty() {

--- a/src/main_tests/search.rs
+++ b/src/main_tests/search.rs
@@ -10,6 +10,7 @@ fn state() -> SearchState {
         input_mode: true,
         input: Default::default(),
         searching: false,
+        in_flight: false,
         search_results: Vec::new(),
     }
 }

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -247,11 +247,7 @@ pub(crate) fn render_library(
 /// Split the query at the editor's cursor column (a char index) so the ▏
 /// glyph can be drawn where the cursor actually is. Clamps past-the-end.
 pub(crate) fn split_at_cursor(q: &str, col: usize) -> (&str, &str) {
-    let byte = q
-        .char_indices()
-        .nth(col)
-        .map(|(i, _)| i)
-        .unwrap_or(q.len());
+    let byte = q.char_indices().nth(col).map(|(i, _)| i).unwrap_or(q.len());
     q.split_at(byte)
 }
 

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -87,8 +87,14 @@ pub(crate) fn render_library(
     if total_items == 0 {
         out.hits.scroll = None;
         out.hits.lib = None;
+        let label = empty_list_label(
+            !app.browse.details.is_empty(),
+            app.search.searching,
+            app.search.in_flight,
+            app.browse.library.is_loaded(app.browse.section),
+        );
         f.render_widget(
-            Paragraph::new(Line::from(Span::styled("(empty)", theme.muted())))
+            Paragraph::new(Line::from(Span::styled(label, theme.muted())))
                 .block(Block::default().style(theme.panel())),
             Rect {
                 x: inner.x,
@@ -247,4 +253,61 @@ pub(crate) fn split_at_cursor(q: &str, col: usize) -> (&str, &str) {
         .map(|(i, _)| i)
         .unwrap_or(q.len());
     q.split_at(byte)
+}
+
+/// What an empty list means, in priority order matching `cur_items`:
+/// drill-ins only exist once their items arrived, so an empty one is truly
+/// empty; an active search is "searching…" only while the wire is hot; a
+/// library section is "loading…" until its first delivery (issue #25).
+fn empty_list_label(
+    in_details: bool,
+    searching: bool,
+    search_in_flight: bool,
+    section_loaded: bool,
+) -> &'static str {
+    if in_details {
+        "(empty)"
+    } else if searching {
+        if search_in_flight {
+            "searching…"
+        } else {
+            "(empty)"
+        }
+    } else if !section_loaded {
+        "loading…"
+    } else {
+        "(empty)"
+    }
+}
+
+#[cfg(test)]
+mod empty_label_tests {
+    use super::empty_list_label;
+
+    #[test]
+    fn section_not_yet_delivered_says_loading() {
+        assert_eq!(empty_list_label(false, false, false, false), "loading…");
+    }
+
+    #[test]
+    fn delivered_but_empty_section_says_empty() {
+        assert_eq!(empty_list_label(false, false, false, true), "(empty)");
+    }
+
+    #[test]
+    fn search_in_flight_says_searching() {
+        assert_eq!(empty_list_label(false, true, true, true), "searching…");
+    }
+
+    #[test]
+    fn search_landed_with_no_results_says_empty() {
+        assert_eq!(empty_list_label(false, true, false, true), "(empty)");
+    }
+
+    #[test]
+    fn drill_in_wins_over_everything() {
+        // Details only exist once their items arrived — an empty one is real,
+        // regardless of what the search or library are doing underneath.
+        assert_eq!(empty_list_label(true, true, true, false), "(empty)");
+    }
 }


### PR DESCRIPTION
Closes #25.

**Stacked on #34** (branched from it — shares the `SearchState` shape). GitHub will retarget to `main` automatically when #34 merges.

## What

An empty list now says *why* it's empty instead of always claiming `(empty)`:

| State | Label |
|---|---|
| Library section hasn't received its first delivery (boot, or after `r` refresh) | `loading…` |
| Search submitted, results still on the wire | `searching…` |
| Genuinely nothing there | `(empty)` |

## Design

- **Per-section loaded tracking lives at the single delivery point** — `Library::set()` marks the section; `is_loaded()` / `reset_loading()` / `mark_all_loaded()` round it out. No parallel bookkeeping to drift.
- `r` refresh re-arms loading state; sections with existing items keep rendering them (no label flash), only *empty* sections fall back to `loading…`.
- **Failed fetch (retries exhausted) marks all sections delivered** — the label stays honest (`(empty)`) while the status line carries "library failed — press r to reload". No perpetual `loading…` lie.
- `SearchState.in_flight` distinguishes "the wire is hot" from "search view active" (`searching` already meant the latter). Set on submit, cleared when results land — including the zero-results case, which correctly reads `(empty)` + "no results" status.
- Drill-in details only exist once their items arrive, so an empty drill-in is truly empty — it wins the priority order, matching `cur_items` resolution.
- Label decision extracted as pure `empty_list_label()` — fully unit-tested.

## Testing

7 new tests (5 label-priority cases incl. empty-delivery-counts-as-loaded, 2 tracking lifecycle). Suite: 58 passed / 0 failed; clippy `--tests -D warnings` clean; fmt clean.