### PR TITLE
feat(ui): mark the currently playing track in the list

### DIFF
--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -167,7 +167,14 @@ pub(crate) fn render_library(
         // Mark rows that `P` can play outright (playlist / album / artist), so
         // they're distinguishable from tracks at a glance.
         let playable_ctx = context_target(item).is_some() && !item.is_play;
-        let max = if playable_ctx {
+        // The currently playing track, wherever it appears in the list (#33).
+        let now_here = item.is_track
+            && app
+                .playback
+                .now
+                .as_ref()
+                .is_some_and(|n| n.uri == item.uri);
+        let max = if playable_ctx || now_here {
             max.saturating_sub(2)
         } else {
             max
@@ -180,6 +187,24 @@ pub(crate) fn render_library(
                 Style::default().fg(theme.border_dimmest.into()),
             ));
         }
+        if now_here {
+            // ♪ in accent while playing; dimmed when paused. The label also
+            // takes the accent so the row reads at a glance without selection.
+            let is_playing = app.playback.now.as_ref().is_some_and(|n| n.is_playing);
+            let marker_style = if is_playing {
+                Style::default().fg(theme.accent.into())
+            } else {
+                Style::default()
+                    .fg(theme.accent.into())
+                    .add_modifier(Modifier::DIM)
+            };
+            spans.push(Span::styled(" ♪", marker_style));
+        }
+        let style = if now_here && !selected {
+            Style::default().fg(theme.accent.into())
+        } else {
+            style
+        };
         spans.push(Span::styled(format!(" {label}"), style));
         if !item.subtitle.is_empty() {
             let used = label.chars().count() + 1;

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -188,7 +188,9 @@ pub(crate) fn render_library(
             // weight is the signal (boss's call over the accented ♪).
             let is_playing = app.playback.now.as_ref().is_some_and(|n| n.is_playing);
             let marker_style = if is_playing {
-                Style::default().add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(theme.accent.into())
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().add_modifier(Modifier::DIM)
             };

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -168,12 +168,8 @@ pub(crate) fn render_library(
         // they're distinguishable from tracks at a glance.
         let playable_ctx = context_target(item).is_some() && !item.is_play;
         // The currently playing track, wherever it appears in the list (#33).
-        let now_here = item.is_track
-            && app
-                .playback
-                .now
-                .as_ref()
-                .is_some_and(|n| n.uri == item.uri);
+        let now_here =
+            item.is_track && app.playback.now.as_ref().is_some_and(|n| n.uri == item.uri);
         let max = if playable_ctx || now_here {
             max.saturating_sub(2)
         } else {

--- a/src/ui/library.rs
+++ b/src/ui/library.rs
@@ -184,23 +184,16 @@ pub(crate) fn render_library(
             ));
         }
         if now_here {
-            // ♪ in accent while playing; dimmed when paused. The label also
-            // takes the accent so the row reads at a glance without selection.
+            // Bold ● while playing, dimmed while paused. No color — the
+            // weight is the signal (boss's call over the accented ♪).
             let is_playing = app.playback.now.as_ref().is_some_and(|n| n.is_playing);
             let marker_style = if is_playing {
-                Style::default().fg(theme.accent.into())
+                Style::default().add_modifier(Modifier::BOLD)
             } else {
-                Style::default()
-                    .fg(theme.accent.into())
-                    .add_modifier(Modifier::DIM)
+                Style::default().add_modifier(Modifier::DIM)
             };
-            spans.push(Span::styled(" ♪", marker_style));
+            spans.push(Span::styled(" ●", marker_style));
         }
-        let style = if now_here && !selected {
-            Style::default().fg(theme.accent.into())
-        } else {
-            style
-        };
         spans.push(Span::styled(format!(" {label}"), style));
         if !item.subtitle.is_empty() {
             let used = label.chars().count() + 1;


### PR DESCRIPTION
Closes #33.

**Stacked on #35** (→ #34 → main). Retargets automatically as the chain merges.

## What

The currently playing track gets a `♪` marker and an accent-colored label wherever it appears in the left-hand list — library sections, search results, drill-ins. Requested in #33.

- `♪` renders in the accent color while playing, **dimmed while paused** — glanceable transport state
- The label takes the accent too (unless the row is selected, where selection style wins)
- Same gutter pattern as the existing playable-context `▶` marker; width math adjusted identically
- Matching is by playhead URI (`playback.now.uri`) against `LibItem.uri`, tracks only

## Testing

Suite green (58/0), clippy `--tests -D warnings` clean, fmt clean. Visual behavior verified against the release build on the dev box.