### PR TITLE
fix: avoid cover repaint on compositor focus

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -621,12 +621,13 @@ async fn run_ui(
                             break;
                         }
                     }
-                    // A repaint from the terminal's own buffer loses inline art.
-                    // A repaint from the terminal's own buffer loses inline art;
-                    // returning to the window is when it has to go back out.
-                    // tmux only forwards focus with `focus-events on` — see the
-                    // README — and stores sixel itself either way.
-                    Ok(Event::Resize(..)) | Ok(Event::FocusGained) => {
+                    // Resizes lose inline art. Focus only does so when tmux
+                    // repaints a pane; compositor focus-follows-mouse events do
+                    // not and must not make the cover flash.
+                    Ok(Event::Resize(..)) => {
+                        app.art_repaint = ArtRepaint::Wipe;
+                    }
+                    Ok(Event::FocusGained) if std::env::var_os("TMUX").is_some() => {
                         app.art_repaint = ArtRepaint::Wipe;
                     }
                     _ => {}


### PR DESCRIPTION
## Summary
- keep ordinary compositor focus events from wiping and retransmitting album art
- preserve resize-triggered repaints
- preserve the tmux focus workaround for pane-buffer repaints

## Why
Hyprland focus-follows-mouse emits `FocusGained` when the pointer enters the terminal. Treating every such event like a lost terminal buffer caused the cover to be blanked for one frame and sent again, producing a visible flash.

## Testing
- `cargo fmt --check`
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`