### PR TITLE
fix(macos): media controls work without terminal focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Newest first. Format follows [Keep a Changelog](https://keepachangelog.com);
 versions follow [semver](https://semver.org). Released sections are a record —
 they are added to, never rewritten.
 
+## [Unreleased]
+
+### Fixed
+
+- macOS: AirPods, headphone and Control Center controls now work without the
+  terminal focused. The handlers were registered but nothing ran the
+  main-thread event loop that delivers them.
+
+
 ## [0.4.0] — 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ z          hide sidebar          q        quit
 ```
 
 Media keys (Play/Pause, Stop, Next, Prev, Volume) work when the terminal is
-focused. Mouse works too: click tabs, click a track, double-click to play.
+focused. On macOS and Linux, AirPods and headphone controls work from anywhere
+via the system's Now Playing integration. Mouse works too: click tabs, click a
+track, double-click to play.
 
 Holding `⇧ ←` / `⇧ →` scrubs continuously and commits one seek when you let go.
 `⇧ ⏎` needs a terminal that reports modified Enter (kitty, WezTerm, foot); `P`

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> Result<()> {
     if engine::needs_authorization() || !WebApi::is_cached() {
         println!("myx: first run — authorizing with Spotify…");
     }
-    let ((creds, webapi), mut terminal) = auth_then_terminal(
+    let ((creds, webapi), terminal) = auth_then_terminal(
         || {
             let creds = engine::credentials()?;
             let webapi = WebApi::init().context("authorize web api")?;
@@ -123,12 +123,36 @@ fn main() -> Result<()> {
         picker.font_size()
     ));
 
+    #[cfg(target_os = "macos")]
+    let res = run_player_macos(terminal, saved, init_vol, creds, webapi, picker);
+    #[cfg(not(target_os = "macos"))]
+    let res = run_player(terminal, saved, init_vol, creds, webapi, picker, true);
+    res
+}
+
+fn run_player(
+    mut terminal: Term,
+    saved: SavedState,
+    init_vol: u8,
+    creds: librespot_core::authentication::Credentials,
+    webapi: WebApi,
+    picker: Picker,
+    media_platform_ready: bool,
+) -> Result<()> {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(4)
         .enable_all()
         .build()
         .context("start tokio runtime")?;
-    let outcome = runtime.block_on(boot(&mut terminal, saved, init_vol, creds, webapi, picker));
+    let outcome = runtime.block_on(boot(
+        &mut terminal,
+        saved,
+        init_vol,
+        creds,
+        webapi,
+        picker,
+        media_platform_ready,
+    ));
     let restored = restore_terminal(&mut terminal);
     // Say goodbye *after* the screen is back, so a subscriber that has stopped
     // reading can never hold the alternate screen open while `shutdown` waits
@@ -144,6 +168,69 @@ fn main() -> Result<()> {
     };
     restored?;
     res
+}
+
+/// macOS delivers Now Playing commands (AirPods, Control Center) through the
+/// main thread's run loop, so the winit loop takes the main thread and the
+/// player runs beside it. No loop only costs the native integration.
+#[cfg(target_os = "macos")]
+fn run_player_macos(
+    terminal: Term,
+    saved: SavedState,
+    init_vol: u8,
+    creds: librespot_core::authentication::Credentials,
+    webapi: WebApi,
+    picker: Picker,
+) -> Result<()> {
+    use winit::application::ApplicationHandler;
+    use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+    use winit::platform::macos::{ActivationPolicy, EventLoopBuilderExtMacOS};
+
+    struct PlayerDone;
+
+    struct MediaPump;
+    impl ApplicationHandler<PlayerDone> for MediaPump {
+        fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+            event_loop.set_control_flow(ControlFlow::Wait);
+        }
+        fn window_event(
+            &mut self,
+            _: &ActiveEventLoop,
+            _: winit::window::WindowId,
+            _: winit::event::WindowEvent,
+        ) {
+        }
+        fn user_event(&mut self, event_loop: &ActiveEventLoop, _: PlayerDone) {
+            event_loop.exit();
+        }
+    }
+
+    // Accessory keeps myx out of the Dock and the app switcher.
+    let event_loop = match EventLoop::<PlayerDone>::with_user_event()
+        .with_activation_policy(ActivationPolicy::Accessory)
+        .build()
+    {
+        Ok(event_loop) => event_loop,
+        Err(e) => {
+            liblog(format!("media event loop unavailable: {e}"));
+            return run_player(terminal, saved, init_vol, creds, webapi, picker, false);
+        }
+    };
+
+    let proxy = event_loop.create_proxy();
+    let player = std::thread::spawn(move || {
+        let res = run_player(terminal, saved, init_vol, creds, webapi, picker, true);
+        let _ = proxy.send_event(PlayerDone);
+        res
+    });
+
+    if let Err(e) = event_loop.run_app(&mut MediaPump) {
+        liblog(format!("media event loop stopped: {e}"));
+    }
+    match player.join() {
+        Ok(res) => res,
+        Err(_) => Err(anyhow::anyhow!("player thread panicked")),
+    }
 }
 
 /// What `boot` hands back so `main` can say goodbye on the exit path.
@@ -226,6 +313,7 @@ async fn boot(
     creds: librespot_core::authentication::Credentials,
     webapi: WebApi,
     picker: Picker,
+    media_platform_ready: bool,
 ) -> Result<MxcHandle> {
     let (ev_tx, ev_rx) = flume::unbounded::<EngineEvent>();
     let engine = with_loader(
@@ -267,15 +355,6 @@ async fn boot(
     // Myx is a TUI with no window of its own, get the console's window instead.
     #[cfg(windows)]
     let hwnd = Some(unsafe { windows_win::sys::GetConsoleWindow() });
-
-    // macOS media controls require an event loop. Failure only disables native
-    // integration; the terminal player remains fully usable.
-    #[cfg(target_os = "macos")]
-    let media_event_loop = winit::event_loop::EventLoop::new().ok();
-    #[cfg(not(target_os = "macos"))]
-    let media_platform_ready = true;
-    #[cfg(target_os = "macos")]
-    let media_platform_ready = media_event_loop.is_some();
 
     let media_controls = optional_integration(media_platform_ready, || {
         MediaControls::new(PlatformConfig {


### PR DESCRIPTION
Closes #41.

## What

Headphone and Control Center controls now work on macOS without the terminal being focused.

- The souvlaki command handlers were registered, but macOS delivers media-remote events through the main thread's run loop, and nothing was running one
- The winit event loop now takes the main thread (Accessory policy, so no Dock icon) and the player runs on its own thread
- If the loop can't be built (SSH, headless), myx falls back to the previous single-threaded path without native controls
- Linux and Windows paths unchanged

## Testing

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features` clean
- `cargo test --all-features` (213 passed, 6 ignored)
- Manual on an Apple Silicon Mac: play/pause, next and previous from headphones with the terminal unfocused; Control Center shows the track; no Dock icon; `q` exits cleanly with no orphaned process