### PR TITLE
fix(ui): restore cover without blank repaint

### DIFF
--- a/src/app/frame.rs
+++ b/src/app/frame.rs
@@ -29,6 +29,9 @@ pub(crate) struct HitRects {
 #[derive(Default)]
 pub(crate) struct FrameOut {
     pub(crate) hits: HitRects,
+    /// Album-art footprint in the current frame. Used to restore pixels that
+    /// an overlay covered without forcing a blank intermediate frame.
+    pub(crate) art: Option<Rect>,
     /// Library viewport start row. Unlike `hits`, this is read-modify-write:
     /// the renderer feeds the previous frame's value into `scroll_offset` and
     /// stores the result back, which is what makes scrolling sticky. Owned by
@@ -41,8 +44,10 @@ pub(crate) struct FrameOut {
 /// `ratatui-image` puts the whole image in one cell's symbol and marks the rest
 /// of the box `Skip`, which the diff never touches again — so leftovers stay,
 /// and a re-encode is byte-identical for sixel and iTerm2 and gets discarded.
-/// Blanking the box for one frame is the only change the diff will emit, and it
-/// makes the image that follows one too.
+/// Blanking the box for one frame forces the diff to emit a changed image on
+/// the next. Overlay restoration bypasses this state and replays the cached
+/// protocol directly, but resizes and layout changes still need the wipe to
+/// remove the old footprint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ArtRepaint {
     /// The box holds what it should.

--- a/src/cover.rs
+++ b/src/cover.rs
@@ -5,13 +5,19 @@
 //! The encoded protocol is cached per render area — re-encoding only happens when
 //! the cover box changes size, keeping the render loop cheap.
 
+use crossterm::cursor::{RestorePosition, SavePosition};
+use crossterm::queue;
 use image::DynamicImage;
+use ratatui::backend::{Backend, CrosstermBackend};
+use ratatui::buffer::Buffer;
 use ratatui::layout::{Rect, Size};
+use ratatui::widgets::Widget;
 use ratatui::Frame;
 use ratatui_image::picker::{Picker, ProtocolType};
 use ratatui_image::protocol::Protocol;
 use ratatui_image::{Image, Resize};
 use std::cell::RefCell;
+use std::io::{self, Write};
 use std::sync::OnceLock;
 
 pub struct Cover {
@@ -114,8 +120,48 @@ impl Cover {
     }
 
     pub fn render(&self, frame: &mut Frame, area: Rect) {
-        if area.width == 0 || area.height == 0 {
+        if !self.ensure_cached(area) {
             return;
+        }
+        let cached = self.cached.borrow();
+        if let Some((_, protocol)) = &*cached {
+            frame.render_widget(Image::new(protocol), area);
+        }
+    }
+
+    /// Replay the cached protocol straight to a terminal writer.
+    ///
+    /// This is used after a popup that covered the image closes. Going through
+    /// the regular terminal diff can discard a byte-identical image anchor, so
+    /// render it against a fresh buffer and send that diff in the same
+    /// synchronized update as the popup-free frame.
+    pub fn render_direct<W: Write>(&self, writer: &mut W, area: Rect) -> io::Result<()> {
+        if !self.ensure_cached(area) {
+            return Ok(());
+        }
+
+        let cached = self.cached.borrow();
+        let Some((_, protocol)) = &*cached else {
+            return Ok(());
+        };
+        let previous = Buffer::empty(area);
+        let mut current = Buffer::empty(area);
+        Image::new(protocol).render(area, &mut current);
+
+        queue!(writer, SavePosition)?;
+        {
+            let mut backend = CrosstermBackend::new(&mut *writer);
+            backend.draw(previous.diff_iter(&current))?;
+        }
+        queue!(writer, RestorePosition)?;
+        writer.flush()
+    }
+
+    /// Make sure the protocol cache matches `area`. A failed encode leaves the
+    /// cache empty and both rendering paths become a no-op.
+    fn ensure_cached(&self, area: Rect) -> bool {
+        if area.width == 0 || area.height == 0 {
+            return false;
         }
         let mut cached = self.cached.borrow_mut();
         let needs_encode = cached
@@ -130,13 +176,10 @@ impl Cover {
                 Resize::Fit(None),
             ) {
                 Ok(protocol) => *cached = Some((area, protocol)),
-                Err(_) => return,
+                Err(_) => return false,
             }
         }
-
-        if let Some((_, protocol)) = &*cached {
-            frame.render_widget(Image::new(protocol), area);
-        }
+        true
     }
 }
 
@@ -265,6 +308,25 @@ mod tests {
         // Outside tmux there is no reply at all, and nothing may be inferred:
         // guessing kitty here would send escapes a plain terminal prints raw.
         assert_eq!(parse_client_info(""), (false, false));
+    }
+
+    #[test]
+    fn cached_cover_can_be_replayed_without_a_blank_frame() {
+        let img = DynamicImage::ImageRgb8(image::RgbImage::from_pixel(
+            4,
+            4,
+            image::Rgb([24, 120, 220]),
+        ));
+        let cover = Cover::from_image(img, Picker::halfblocks());
+        let mut output = Vec::new();
+
+        cover
+            .render_direct(&mut output, Rect::new(3, 2, 4, 2))
+            .expect("direct cover render");
+
+        assert!(!output.is_empty());
+        assert!(String::from_utf8_lossy(&output).contains('▀'));
+        assert!(!cover.needs_send(Rect::new(3, 2, 4, 2)));
     }
 
     /// What one cover re-encode costs on the UI thread, per protocol. Ignored

--- a/src/main.rs
+++ b/src/main.rs
@@ -567,6 +567,9 @@ async fn run_ui(
     let mut dirty = true;
     let mut last_layout = (app.view.mode, app.view.zen);
     let mut overlay_open = app.view.actions.is_some();
+    // A popup overwrites inline-image pixels. Replay the cached cover after the
+    // popup-free frame instead of blanking it for one visible frame first.
+    let mut restore_art = false;
     // What the renderer writes. Lives across frames: the hit rects are what the
     // mouse handler reads between draws, and `lib_offset` is fed back into the
     // next frame's sticky-viewport calculation.
@@ -662,7 +665,7 @@ async fn run_ui(
                 if overlay != overlay_open {
                     overlay_open = overlay;
                     if !overlay {
-                        app.art_repaint = ArtRepaint::Wipe;
+                        restore_art = true;
                     }
                     dirty = true;
                 }
@@ -674,10 +677,35 @@ async fn run_ui(
                     // Terminals that don't know the mode ignore it.
                     let _ = execute!(io::stdout(), BeginSynchronizedUpdate);
                     let repaint = app.art_repaint;
-                    let drawn = terminal.draw(|f| render(f, &app, &mut out, repaint));
+                    let drawn = terminal
+                        .draw(|f| render(f, &app, &mut out, repaint))
+                        .map(|_| ());
+                    let restore_result = if drawn.is_ok()
+                        && restore_art
+                        && !overlay_open
+                        && app.view.mode == RightView::NowPlaying
+                    {
+                        out.art
+                            .zip(
+                                app.playback
+                                    .now
+                                    .as_ref()
+                                    .and_then(|now| now.cover.as_ref()),
+                            )
+                            .map(|(area, cover)| cover.render_direct(terminal.backend_mut(), area))
+                    } else {
+                        None
+                    };
                     let _ = execute!(io::stdout(), EndSynchronizedUpdate);
                     drawn?;
                     app.art_repaint = app.art_repaint.advance();
+                    if restore_art && !overlay_open {
+                        restore_art = false;
+                        if let Some(Err(err)) = restore_result {
+                            liblog(format!("cover restore failed: {err}"));
+                            app.art_repaint = ArtRepaint::Wipe;
+                        }
+                    }
                     last_draw = Instant::now();
                     dirty = false;
                 }
@@ -720,7 +748,7 @@ async fn run_ui(
                         app.art_repaint = ArtRepaint::Wipe;
                     }
                     Ok(Event::FocusGained) if std::env::var_os("TMUX").is_some() => {
-                        app.art_repaint = ArtRepaint::Wipe;
+                        restore_art = true;
                     }
                     _ => {}
                 }

--- a/src/main_tests/nav.rs
+++ b/src/main_tests/nav.rs
@@ -211,9 +211,9 @@ fn zen_keeps_playback_and_the_right_hand_pane() {
 
 #[test]
 fn a_forced_repaint_blanks_the_box_before_redrawing_it() {
-    // The wipe is the whole mechanism: re-encoding is byte-identical for
-    // sixel and iTerm2, so a blank frame is the only thing the diff will
-    // emit — and it takes the overlay's leftovers with it.
+    // Resizes and layout changes still need a wipe because the previous image
+    // footprint may no longer match. Popup restoration uses the direct cached
+    // replay path instead, so it does not expose this blank intermediate frame.
     assert_eq!(ArtRepaint::Wipe.advance(), ArtRepaint::Draw);
     assert_eq!(ArtRepaint::Draw.advance(), ArtRepaint::Idle);
     assert_eq!(ArtRepaint::Idle.advance(), ArtRepaint::Idle);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -23,6 +23,7 @@ pub(crate) use visualizer::*;
 use crate::*;
 
 pub(crate) fn render(f: &mut Frame, app: &App, out: &mut FrameOut, repaint: ArtRepaint) {
+    out.art = None;
     let theme = app.theme.displayed;
     let area = f.area();
     f.render_widget(Block::default().style(theme.base()), area);
@@ -101,7 +102,7 @@ pub(crate) fn render(f: &mut Frame, app: &App, out: &mut FrameOut, repaint: ArtR
         body[1]
     };
     match app.view.mode {
-        RightView::NowPlaying => render_nowplaying_view(f, app, theme, right, repaint),
+        RightView::NowPlaying => render_nowplaying_view(f, app, out, theme, right, repaint),
         RightView::Lyrics => render_lyrics(f, app, theme, right),
         RightView::Queue => render_queue_view(f, app, theme, right),
     }

--- a/src/ui/nowplaying.rs
+++ b/src/ui/nowplaying.rs
@@ -7,6 +7,7 @@ use crate::*;
 pub(crate) fn render_nowplaying_view(
     f: &mut Frame,
     app: &App,
+    out: &mut FrameOut,
     theme: Theme,
     area: Rect,
     repaint: ArtRepaint,
@@ -64,6 +65,7 @@ pub(crate) fn render_nowplaying_view(
         width: art_w,
         height: art_h,
     };
+    out.art = Some(art_rect);
 
     match app.playback.now.as_ref().and_then(|n| n.cover.as_ref()) {
         _ if repaint == ArtRepaint::Wipe => wipe_area(f, art_rect),


### PR DESCRIPTION
## Summary
- replay cached album art directly after an overlay closes instead of blanking it for an intermediate frame
- apply the same flash-free restoration when returning to a tmux pane
- retain the existing wipe/redraw cycle for resizes and layout changes where the old image footprint must be cleared
- add a regression test for direct cached cover replay

## Testing
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo check --no-default-features --features mxc`
- `git diff --check`