### PR TITLE
feat: add interactive ten-band equalizer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,7 @@ construction.
 | `engine/mod.rs` | The librespot engine. Brings up a Spotify Connect device (Spirc) with our tee'd audio sink, and bridges librespot's player events into a clean `EngineEvent` stream. `TrackChanged` landing on that channel is what makes track changes *real* — it's the hook the theme fade and cover reload fire from. Also `radio_tracks` (seeded autoplay). |
 | `engine/auth.rs` | OAuth 2.0 PKCE against librespot's public desktop client ID, with a tiny localhost callback server. Produces librespot `Credentials`. Adapted from spotify-player (MIT). |
 | `audio/visualizer.rs` | The FFT visualizer sink. It's a **tee**: every audio packet is forwarded unchanged to the real backend (playback is never affected) while a windowed FFT writes frequency bands into a plain `Arc<Mutex<VisBands>>`. |
+| `audio/equalizer.rs` | The ten-band graphic EQ. Cascaded stereo biquads transform PCM before it reaches the visualizer/backend; a shared settings snapshot lets the UI change curves without blocking the audio thread. |
 | `webapi.rs` | The Spotify **Web API** side: a *separate* OAuth PKCE flow using your own app's client ID, so metadata and library calls get their own rate-limit bucket instead of fighting librespot's saturated shared one. Token cached to `~/.cache/myx/webapi.json` and auto-refreshed. |
 | `httpcache.rs` | On-disk cache for catalogue reads (`~/.cache/myx/api`). Spotify's dev quota runs out fast; stale entries are served when a request fails, because yesterday's album list beats an empty page. |
 
@@ -122,6 +123,7 @@ open is the one named after what you're looking at.
 | `ui/library.rs` | Left sidebar: sections, search results, drill-in lists. |
 | `ui/nowplaying.rs` | The Now Playing view *and* the persistent bottom strip (volume, progress). |
 | `ui/lyrics.rs` / `ui/queue.rs` / `ui/visualizer.rs` | The other views and the spectrum bars under the art. |
+| `ui/equalizer.rs` | The modal ten-band equalizer: preset pills, sliders, headroom and its narrow-terminal fallback. |
 | `ui/overlay.rs` | Things drawn on top: the actions menu, the startup loading screen. |
 | `ui/footer.rs` | The one-line keybinding hint. |
 
@@ -152,6 +154,7 @@ the file to open is the one named after where the event came from. It reads
 | `input/key.rs` | The main keymap. |
 | `input/mouse.rs` | Clicks, drags and wheel, resolved against the hit rects. |
 | `input/actions.rs` | Input while the actions overlay is open, plus copy-to-clipboard. |
+| `input/equalizer.rs` | Modal equalizer keyboard/mouse input and the pointer-to-gain mapping. |
 | `input/media.rs` | OS media keys (souvlaki). |
 
 ### The network

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # myx
 
 A lean, beautiful terminal Spotify player in Rust. Streams natively as a Spotify
-Connect device, with album-art-reactive theming, a live audio visualizer, and
-synced lyrics.
+Connect device, with album-art-reactive theming, a live audio visualizer, a
+ten-band equalizer, and synced lyrics.
 
 <p align="center"><video src="https://github.com/user-attachments/assets/90706ba9-4c48-43d0-ad16-17b95c95dc94" alt="myx recolors the whole interface to the album art" width="100%"></p>
 
@@ -71,13 +71,23 @@ space      play · pause          n / b    next · prev
 ⇧ ← →      seek                  s        shuffle
 + / -      volume                R        repeat
 o          sort                  r        reload
-z          hide sidebar          q        quit
+z          hide sidebar          e        equalizer
+q          quit
 ```
 
 Media keys (Play/Pause, Stop, Next, Prev, Volume) work when the terminal is
 focused. On macOS and Linux, AirPods and headphone controls work from anywhere
 via the system's Now Playing integration. Mouse works too: click tabs, click a
 track, double-click to play.
+
+## Equalizer
+
+Press `e` for the live ten-band equalizer. Choose Flat, Bass Boost, Rock, Jazz,
+Vocal, Electronic or Treble Boost with `Tab` / `Shift+Tab`; changing a band
+creates a Custom curve. Use `←`/`→` to choose a band, `↑`/`↓` to adjust it,
+`Space` to compare against bypass, and `Esc` to close. Presets and sliders are
+also clickable and draggable. Automatic headroom keeps boosted curves from
+digitally clipping, and the complete curve is restored on the next launch.
 
 Holding `⇧ ←` / `⇧ →` scrubs continuously and commits one seek when you let go.
 `⇧ ⏎` needs a terminal that reports modified Enter (kitty, WezTerm, foot); `P`

--- a/src/app/frame.rs
+++ b/src/app/frame.rs
@@ -22,6 +22,19 @@ pub(crate) struct HitRects {
     pub(crate) tabs: Vec<(RightView, Rect)>,
     /// Library list viewport.
     pub(crate) lib: Option<Rect>,
+    /// Equalizer overlay controls. Empty whenever that modal is closed.
+    pub(crate) eq_toggle: Option<Rect>,
+    pub(crate) eq_presets: Vec<(EqualizerPreset, Rect)>,
+    pub(crate) eq_bands: Vec<EqualizerBandHit>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct EqualizerBandHit {
+    pub(crate) band: usize,
+    pub(crate) rect: Rect,
+    /// Normal layout uses vertical sliders; the narrow fallback uses one
+    /// horizontal slider for the selected band.
+    pub(crate) vertical: bool,
 }
 
 /// Everything the renderer writes, kept out of `App` so every render function

--- a/src/app/persist.rs
+++ b/src/app/persist.rs
@@ -19,6 +19,8 @@ pub(crate) struct SavedState {
     pub(crate) source: PlaySource,
     #[serde(default)]
     pub(crate) source_name: String,
+    #[serde(default)]
+    pub(crate) equalizer: EqualizerSettings,
 }
 
 #[derive(Default, serde::Serialize, serde::Deserialize)]
@@ -39,6 +41,10 @@ impl SavedState {
         Self::path()
             .and_then(|p| std::fs::read_to_string(p).ok())
             .and_then(|s| serde_json::from_str(&s).ok())
+            .map(|mut state: Self| {
+                state.equalizer = state.equalizer.normalized();
+                state
+            })
             .unwrap_or_default()
     }
     pub(crate) fn save(&self) {
@@ -72,6 +78,34 @@ pub(crate) fn save_state(app: &App) {
         queue_uris: app.transport.queue_uris.clone(),
         source: app.transport.source.clone(),
         source_name: app.transport.source_name.clone(),
+        equalizer: app.transport.equalizer,
     };
     s.save();
+}
+
+#[cfg(test)]
+mod equalizer_persistence_tests {
+    use super::*;
+
+    #[test]
+    fn old_state_without_equalizer_defaults_to_active_flat() {
+        let state: SavedState =
+            serde_json::from_str(r#"{"volume":80,"queue":[],"source_name":""}"#)
+                .expect("old state remains readable");
+        assert_eq!(state.equalizer, EqualizerSettings::default());
+    }
+
+    #[test]
+    fn custom_equalizer_round_trips_with_bypass_state() {
+        let state = SavedState {
+            equalizer: EqualizerSettings {
+                enabled: false,
+                gains_db: [6, 5, 4, 3, 2, 1, 0, -1, -2, -3],
+            },
+            ..Default::default()
+        };
+        let encoded = serde_json::to_string(&state).unwrap();
+        let decoded: SavedState = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.equalizer, state.equalizer);
+    }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -56,6 +56,9 @@ pub(crate) struct Transport {
     // What's playing (context/radio/liked), for faithful resume on reboot.
     pub(crate) source: PlaySource,
     pub(crate) source_name: String,
+    /// Local DSP state. Kept with the transport controls because it affects the
+    /// audio path and is persisted alongside volume/shuffle/repeat.
+    pub(crate) equalizer: EqualizerSettings,
 }
 
 /// The library browser: what's loaded, where the cursor is, and the drill-in
@@ -110,6 +113,13 @@ pub(crate) struct ViewState {
     pub(crate) lyrics_synced: bool,
     // Context actions menu overlay (opened with `a`).
     pub(crate) actions: Option<ActionMenu>,
+    // Ten-band equalizer overlay (opened with `e`).
+    pub(crate) equalizer: Option<EqualizerOverlay>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct EqualizerOverlay {
+    pub(crate) selected_band: usize,
 }
 
 /// Cross-cutting session bookkeeping: which metadata fetch is still in flight

--- a/src/audio/equalizer.rs
+++ b/src/audio/equalizer.rs
@@ -1,0 +1,478 @@
+//! Real-time ten-band graphic equalizer.
+//!
+//! The equalizer sits in front of the visualizer and the real audio backend, so
+//! the spectrum on screen is the spectrum the listener actually hears. The
+//! audio thread only checks a tiny shared settings snapshot between packets;
+//! it never waits for the UI and allocates nothing while processing samples.
+
+use std::f64::consts::{PI, SQRT_2};
+use std::sync::{Arc, Mutex, PoisonError, TryLockError};
+
+use librespot_playback::audio_backend::{Sink, SinkResult};
+use librespot_playback::convert::Converter;
+use librespot_playback::decoder::AudioPacket;
+use rustfft::num_complex::Complex;
+use serde::{Deserialize, Serialize};
+
+pub const NUM_EQ_BANDS: usize = 10;
+pub const EQ_FREQUENCIES_HZ: [f64; NUM_EQ_BANDS] = [
+    31.0, 62.0, 125.0, 250.0, 500.0, 1_000.0, 2_000.0, 4_000.0, 8_000.0, 16_000.0,
+];
+pub const MIN_EQ_GAIN_DB: i8 = -12;
+pub const MAX_EQ_GAIN_DB: i8 = 12;
+
+/// Persistable equalizer controls. Derived values such as the automatic
+/// preamp are intentionally omitted and recomputed from the curve.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EqualizerSettings {
+    pub enabled: bool,
+    pub gains_db: [i8; NUM_EQ_BANDS],
+}
+
+impl EqualizerSettings {
+    pub fn normalized(mut self) -> Self {
+        for gain in &mut self.gains_db {
+            *gain = (*gain).clamp(MIN_EQ_GAIN_DB, MAX_EQ_GAIN_DB);
+        }
+        self
+    }
+
+    pub fn is_flat(self) -> bool {
+        self.gains_db.iter().all(|&gain| gain == 0)
+    }
+
+    pub fn set_band(&mut self, band: usize, gain_db: i8) {
+        if let Some(gain) = self.gains_db.get_mut(band) {
+            *gain = gain_db.clamp(MIN_EQ_GAIN_DB, MAX_EQ_GAIN_DB);
+        }
+    }
+
+    /// The automatic preamp applied before the filters, in dB. This is zero
+    /// for a bypassed/flat curve and negative for a curve whose combined
+    /// response rises above unity.
+    pub fn auto_preamp_db(self) -> f64 {
+        let settings = self.normalized();
+        if !settings.enabled || settings.is_flat() {
+            return 0.0;
+        }
+        let coeffs = coefficients(settings, SAMPLE_RATE);
+        -peak_response_db(&coeffs, SAMPLE_RATE).max(0.0)
+    }
+}
+
+impl Default for EqualizerSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            gains_db: [0; NUM_EQ_BANDS],
+        }
+    }
+}
+
+/// Built-in curves. A manually edited curve is represented in the UI as
+/// `Custom`; it is deliberately not a preset because its values are the state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EqualizerPreset {
+    Flat,
+    BassBoost,
+    Rock,
+    Jazz,
+    Vocal,
+    Electronic,
+    TrebleBoost,
+}
+
+impl EqualizerPreset {
+    pub const ALL: [Self; 7] = [
+        Self::Flat,
+        Self::BassBoost,
+        Self::Rock,
+        Self::Jazz,
+        Self::Vocal,
+        Self::Electronic,
+        Self::TrebleBoost,
+    ];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Flat => "Flat",
+            Self::BassBoost => "Bass Boost",
+            Self::Rock => "Rock",
+            Self::Jazz => "Jazz",
+            Self::Vocal => "Vocal",
+            Self::Electronic => "Electronic",
+            Self::TrebleBoost => "Treble Boost",
+        }
+    }
+
+    pub const fn short_label(self) -> &'static str {
+        match self {
+            Self::BassBoost => "Bass",
+            Self::Electronic => "Electro",
+            Self::TrebleBoost => "Treble",
+            other => other.label(),
+        }
+    }
+
+    pub const fn gains_db(self) -> [i8; NUM_EQ_BANDS] {
+        match self {
+            Self::Flat => [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            Self::BassBoost => [6, 6, 5, 4, 2, 0, -1, -2, -2, -2],
+            Self::Rock => [4, 3, 2, 0, -2, -1, 1, 3, 4, 4],
+            Self::Jazz => [3, 2, 1, 2, -1, -1, 0, 1, 2, 3],
+            Self::Vocal => [-3, -2, -1, 1, 3, 4, 3, 1, -1, -2],
+            Self::Electronic => [4, 3, 1, 0, -2, 1, 2, 3, 4, 3],
+            Self::TrebleBoost => [-2, -2, -2, -1, 0, 2, 4, 5, 6, 6],
+        }
+    }
+
+    pub fn from_gains(gains_db: &[i8; NUM_EQ_BANDS]) -> Option<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|preset| preset.gains_db() == *gains_db)
+    }
+}
+
+pub(crate) type EqualizerControl = Arc<Mutex<EqualizerSettings>>;
+
+pub(crate) fn shared_equalizer() -> EqualizerControl {
+    Arc::new(Mutex::new(EqualizerSettings::default()))
+}
+
+const SAMPLE_RATE: f64 = 44_100.0;
+const HEADROOM_RAMP_FRAMES: usize = 882; // 20ms at 44.1kHz
+const RESPONSE_POINTS: usize = 1_024;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct Coefficients {
+    b0: f64,
+    b1: f64,
+    b2: f64,
+    a1: f64,
+    a2: f64,
+}
+
+impl Coefficients {
+    const IDENTITY: Self = Self {
+        b0: 1.0,
+        b1: 0.0,
+        b2: 0.0,
+        a1: 0.0,
+        a2: 0.0,
+    };
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct FilterState {
+    z1: f64,
+    z2: f64,
+}
+
+impl FilterState {
+    #[inline]
+    fn process(&mut self, input: f64, coeffs: Coefficients) -> f64 {
+        // Transposed direct form II: two delay values and good numerical
+        // behaviour when ten sections are cascaded.
+        let output = coeffs.b0 * input + self.z1;
+        self.z1 = coeffs.b1 * input - coeffs.a1 * output + self.z2;
+        self.z2 = coeffs.b2 * input - coeffs.a2 * output;
+        output
+    }
+}
+
+struct FilterBank {
+    settings: EqualizerSettings,
+    coeffs: [Coefficients; NUM_EQ_BANDS],
+    states: [[FilterState; NUM_EQ_BANDS]; 2],
+    preamp: f64,
+    target_preamp: f64,
+    preamp_step: f64,
+    ramp_frames: usize,
+}
+
+impl FilterBank {
+    fn new(settings: EqualizerSettings) -> Self {
+        let settings = settings.normalized();
+        let target_preamp = db_to_linear(settings.auto_preamp_db());
+        Self {
+            settings,
+            coeffs: coefficients(settings, SAMPLE_RATE),
+            states: [[FilterState::default(); NUM_EQ_BANDS]; 2],
+            preamp: target_preamp,
+            target_preamp,
+            preamp_step: 0.0,
+            ramp_frames: 0,
+        }
+    }
+
+    fn update(&mut self, settings: EqualizerSettings) {
+        let settings = settings.normalized();
+        if settings == self.settings {
+            return;
+        }
+        self.settings = settings;
+        self.coeffs = coefficients(settings, SAMPLE_RATE);
+        self.target_preamp = db_to_linear(settings.auto_preamp_db());
+        if !settings.enabled || settings.is_flat() {
+            self.reset_states();
+            // Bypass really is unity. Starting the next enabled curve from
+            // unity also makes the headroom transition do what the ear expects.
+            self.preamp = 1.0;
+            self.target_preamp = 1.0;
+            self.preamp_step = 0.0;
+            self.ramp_frames = 0;
+        } else {
+            // More attenuation has to land with the boosted coefficients or a
+            // preset change could clip during the ramp. Returning towards
+            // unity may be smoothed safely.
+            if self.target_preamp < self.preamp {
+                self.preamp = self.target_preamp;
+                self.preamp_step = 0.0;
+                self.ramp_frames = 0;
+            } else {
+                self.preamp_step = (self.target_preamp - self.preamp) / HEADROOM_RAMP_FRAMES as f64;
+                self.ramp_frames = HEADROOM_RAMP_FRAMES;
+            }
+        }
+    }
+
+    fn process_interleaved(&mut self, samples: &mut [f64]) {
+        if !self.settings.enabled || self.settings.is_flat() {
+            return;
+        }
+        for frame in samples.chunks_mut(2) {
+            if self.ramp_frames > 0 {
+                self.preamp += self.preamp_step;
+                self.ramp_frames -= 1;
+                if self.ramp_frames == 0 {
+                    self.preamp = self.target_preamp;
+                }
+            }
+            for (channel, sample) in frame.iter_mut().enumerate() {
+                let mut value = *sample * self.preamp;
+                for (state, &coeffs) in self.states[channel].iter_mut().zip(self.coeffs.iter()) {
+                    value = state.process(value, coeffs);
+                }
+                *sample = value;
+            }
+        }
+    }
+
+    fn reset_states(&mut self) {
+        self.states = [[FilterState::default(); NUM_EQ_BANDS]; 2];
+    }
+}
+
+/// A transforming sink: unlike the visualizer tee, this intentionally replaces
+/// sample packets before forwarding them to the next sink.
+pub(crate) struct EqualizerSink {
+    inner: Box<dyn Sink>,
+    control: EqualizerControl,
+    filters: FilterBank,
+}
+
+impl EqualizerSink {
+    pub(crate) fn new(inner: Box<dyn Sink>, control: EqualizerControl) -> Self {
+        let settings = *control.lock().unwrap_or_else(PoisonError::into_inner);
+        Self {
+            inner,
+            control,
+            filters: FilterBank::new(settings),
+        }
+    }
+
+    fn refresh_settings(&mut self) {
+        let settings = match self.control.try_lock() {
+            Ok(settings) => *settings,
+            Err(TryLockError::WouldBlock) => return,
+            Err(TryLockError::Poisoned(error)) => *error.into_inner(),
+        };
+        self.filters.update(settings);
+    }
+}
+
+impl Sink for EqualizerSink {
+    fn start(&mut self) -> SinkResult<()> {
+        self.filters.reset_states();
+        self.inner.start()
+    }
+
+    fn stop(&mut self) -> SinkResult<()> {
+        self.filters.reset_states();
+        self.inner.stop()
+    }
+
+    fn write(&mut self, mut packet: AudioPacket, converter: &mut Converter) -> SinkResult<()> {
+        self.refresh_settings();
+        if let AudioPacket::Samples(samples) = &mut packet {
+            self.filters.process_interleaved(samples);
+        }
+        self.inner.write(packet, converter)
+    }
+}
+
+fn coefficients(settings: EqualizerSettings, sample_rate: f64) -> [Coefficients; NUM_EQ_BANDS] {
+    std::array::from_fn(|band| {
+        let gain = settings.gains_db[band];
+        if gain == 0 {
+            Coefficients::IDENTITY
+        } else {
+            peaking_coefficients(EQ_FREQUENCIES_HZ[band], f64::from(gain), sample_rate)
+        }
+    })
+}
+
+/// Robert Bristow-Johnson Audio EQ Cookbook peaking-EQ coefficients, normalized
+/// by a0 so the hot path needs five multiplies per section.
+fn peaking_coefficients(frequency: f64, gain_db: f64, sample_rate: f64) -> Coefficients {
+    let amplitude = 10.0_f64.powf(gain_db / 40.0);
+    let omega = 2.0 * PI * frequency / sample_rate;
+    let alpha = omega.sin() / (2.0 * SQRT_2);
+    let cos = omega.cos();
+    let a0 = 1.0 + alpha / amplitude;
+    Coefficients {
+        b0: (1.0 + alpha * amplitude) / a0,
+        b1: (-2.0 * cos) / a0,
+        b2: (1.0 - alpha * amplitude) / a0,
+        a1: (-2.0 * cos) / a0,
+        a2: (1.0 - alpha / amplitude) / a0,
+    }
+}
+
+fn peak_response_db(coeffs: &[Coefficients; NUM_EQ_BANDS], sample_rate: f64) -> f64 {
+    let max_frequency = 20_000.0_f64.min(sample_rate * 0.49);
+    let ratio = max_frequency / 20.0;
+    (0..RESPONSE_POINTS)
+        .map(|point| {
+            let t = point as f64 / (RESPONSE_POINTS - 1) as f64;
+            let frequency = 20.0 * ratio.powf(t);
+            cascade_response_db(coeffs, frequency, sample_rate)
+        })
+        .fold(f64::NEG_INFINITY, f64::max)
+}
+
+fn cascade_response_db(
+    coeffs: &[Coefficients; NUM_EQ_BANDS],
+    frequency: f64,
+    sample_rate: f64,
+) -> f64 {
+    let omega = 2.0 * PI * frequency / sample_rate;
+    let z1 = Complex::from_polar(1.0, -omega);
+    let z2 = Complex::from_polar(1.0, -2.0 * omega);
+    coeffs
+        .iter()
+        .map(|c| {
+            let numerator = c.b0 + c.b1 * z1 + c.b2 * z2;
+            let denominator = 1.0 + c.a1 * z1 + c.a2 * z2;
+            20.0 * (numerator / denominator).norm().log10()
+        })
+        .sum()
+}
+
+fn db_to_linear(db: f64) -> f64 {
+    10.0_f64.powf(db / 20.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_active_flat_and_normalization_clamps_saved_values() {
+        let default = EqualizerSettings::default();
+        assert!(default.enabled);
+        assert!(default.is_flat());
+
+        let normalized = EqualizerSettings {
+            enabled: true,
+            gains_db: [-30, 30, 0, 0, 0, 0, 0, 0, 0, 0],
+        }
+        .normalized();
+        assert_eq!(normalized.gains_db[0], MIN_EQ_GAIN_DB);
+        assert_eq!(normalized.gains_db[1], MAX_EQ_GAIN_DB);
+    }
+
+    #[test]
+    fn presets_are_valid_unique_curves_and_recognize_exact_matches() {
+        for (index, preset) in EqualizerPreset::ALL.iter().enumerate() {
+            let gains = preset.gains_db();
+            assert!(gains
+                .iter()
+                .all(|gain| (MIN_EQ_GAIN_DB..=MAX_EQ_GAIN_DB).contains(gain)));
+            assert_eq!(EqualizerPreset::from_gains(&gains), Some(*preset));
+            for other in &EqualizerPreset::ALL[index + 1..] {
+                assert_ne!(gains, other.gains_db());
+            }
+        }
+    }
+
+    #[test]
+    fn flat_and_bypass_are_exact_passthroughs() {
+        let input = [0.25, -0.5, 0.75, -1.0];
+        for settings in [
+            EqualizerSettings::default(),
+            EqualizerSettings {
+                enabled: false,
+                gains_db: EqualizerPreset::BassBoost.gains_db(),
+            },
+        ] {
+            let mut samples = input;
+            FilterBank::new(settings).process_interleaved(&mut samples);
+            assert_eq!(samples, input);
+        }
+    }
+
+    #[test]
+    fn automatic_preamp_cancels_the_sampled_peak_response() {
+        for preset in EqualizerPreset::ALL {
+            let settings = EqualizerSettings {
+                enabled: true,
+                gains_db: preset.gains_db(),
+            };
+            let coeffs = coefficients(settings, SAMPLE_RATE);
+            let compensated = peak_response_db(&coeffs, SAMPLE_RATE) + settings.auto_preamp_db();
+            assert!(compensated <= 1e-9, "{}: {compensated}", preset.label());
+        }
+    }
+
+    #[test]
+    fn stereo_channels_keep_independent_filter_history() {
+        let settings = EqualizerSettings {
+            enabled: true,
+            gains_db: EqualizerPreset::BassBoost.gains_db(),
+        };
+        let mut filters = FilterBank::new(settings);
+        let mut samples = vec![0.0; 4_096];
+        samples[0] = 0.5; // left-channel impulse; right stays silent
+        filters.process_interleaved(&mut samples);
+        assert!(samples.iter().step_by(2).any(|sample| sample.abs() > 0.0));
+        assert!(samples
+            .iter()
+            .skip(1)
+            .step_by(2)
+            .all(|sample| *sample == 0.0));
+        assert!(samples.iter().all(|sample| sample.is_finite()));
+    }
+
+    #[test]
+    fn bass_and_treble_presets_tilt_the_expected_ends() {
+        let response = |preset: EqualizerPreset, frequency| {
+            let settings = EqualizerSettings {
+                enabled: true,
+                gains_db: preset.gains_db(),
+            };
+            cascade_response_db(&coefficients(settings, SAMPLE_RATE), frequency, SAMPLE_RATE)
+        };
+        assert!(
+            response(EqualizerPreset::BassBoost, 62.0)
+                - response(EqualizerPreset::BassBoost, 4_000.0)
+                > 6.0
+        );
+        assert!(
+            response(EqualizerPreset::TrebleBoost, 8_000.0)
+                - response(EqualizerPreset::TrebleBoost, 125.0)
+                > 6.0
+        );
+    }
+}

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,5 +1,10 @@
 //! Audio engine internals (streaming feature).
 
+pub mod equalizer;
 pub mod visualizer;
 
+pub use equalizer::{
+    EqualizerPreset, EqualizerSettings, EQ_FREQUENCIES_HZ, MAX_EQ_GAIN_DB, MIN_EQ_GAIN_DB,
+    NUM_EQ_BANDS,
+};
 pub use visualizer::{VisBands, VisualizationSink, NUM_BANDS};

--- a/src/audio/visualizer.rs
+++ b/src/audio/visualizer.rs
@@ -4,10 +4,11 @@
 //! © 2021 Thang Pham). Decoupled here from that app's global state so it writes
 //! to a plain `Arc<Mutex<VisBands>>` that myx owns.
 //!
-//! The design is a **tee'd audio sink**: it forwards every packet unchanged to
-//! the real backend (so playback is never affected) while computing a windowed
-//! FFT on a copy. The hot path is allocation-free and the UI reads the bands via
-//! `try_lock`, so the audio thread never stalls waiting on a render.
+//! The design is a **tee'd audio sink**: it forwards every packet it receives
+//! unchanged to the real backend while computing a windowed FFT on a copy. The
+//! equalizer sits immediately before this sink, so these bands describe the
+//! sound after EQ. The hot path is allocation-free and the UI reads the bands
+//! via `try_lock`, so the audio thread never stalls waiting on a render.
 
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,7 +1,7 @@
 //! The librespot streaming engine.
 //!
-//! Authenticates, brings up a Spotify Connect device (Spirc) with our tee'd FFT
-//! sink, and bridges librespot's player events into a clean [`EngineEvent`]
+//! Authenticates, brings up a Spotify Connect device (Spirc) with our local EQ +
+//! tee'd FFT sinks, and bridges librespot's player events into a clean [`EngineEvent`]
 //! stream. This is what makes "track change" *real*: when Spotify hands us a new
 //! track, a `TrackChanged` lands on the channel — the hook the reactive theme +
 //! cover fade will fire from.
@@ -29,7 +29,8 @@ use librespot_playback::mixer::softmixer::SoftMixer;
 use librespot_playback::mixer::{Mixer, MixerConfig};
 use librespot_playback::player::{self, Player};
 
-use crate::audio::{VisBands, VisualizationSink};
+use crate::audio::equalizer::{shared_equalizer, EqualizerControl, EqualizerSink};
+use crate::audio::{EqualizerSettings, VisBands, VisualizationSink};
 
 /// A normalized playback event surfaced to the rest of the app.
 #[derive(Debug, Clone)]
@@ -87,6 +88,7 @@ struct Inner {
     link: Mutex<Arc<Link>>,
     mixer: Arc<SoftMixer>,
     bands: Arc<Mutex<VisBands>>,
+    equalizer: EqualizerControl,
     events: flume::Sender<EngineEvent>,
     /// First-login credentials, used only until librespot has cached reusable
     /// ones: a first run authenticates with a one-shot OAuth token that a
@@ -108,7 +110,16 @@ impl Inner {
     /// Build a replacement connection and swap it in. The dead one is dropped
     /// afterwards, which stops its player and ends its event bridge.
     async fn reconnect(&self) -> Result<()> {
-        let fresh = Arc::new(connect(&self.creds, &self.mixer, &self.bands, &self.events).await?);
+        let fresh = Arc::new(
+            connect(
+                &self.creds,
+                &self.mixer,
+                &self.bands,
+                &self.equalizer,
+                &self.events,
+            )
+            .await?,
+        );
         let dead = std::mem::replace(
             &mut *self.link.lock().unwrap_or_else(PoisonError::into_inner),
             fresh,
@@ -260,6 +271,15 @@ impl Engine {
         // Sync the volume to Spotify Connect in the background.
         self.command("set volume", |spirc| spirc.set_volume(vol))
     }
+    /// Replace the complete local equalizer curve. The audio sink observes the
+    /// snapshot between packets, so this never waits on or interrupts playback.
+    pub fn set_equalizer(&self, settings: EqualizerSettings) {
+        *self
+            .inner
+            .equalizer
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = settings.normalized();
+    }
     /// Seek to an absolute position in the current track.
     pub fn seek(&self, position_ms: u32) -> Result<()> {
         self.active_command("seek", |spirc| spirc.set_position_ms(position_ms))
@@ -400,17 +420,19 @@ pub async fn run(
     initial_volume_pct: u8,
 ) -> Result<Engine> {
     let bands = VisBands::shared();
+    let equalizer = shared_equalizer();
 
     // 50% volume in librespot's 0..=65535 range.
     let volume: u16 = (u32::from(initial_volume_pct.clamp(0, 100)) * 65535 / 100) as u16;
     let mixer = Arc::new(SoftMixer::open(MixerConfig::default()).context("open softmixer")?);
     mixer.set_volume(volume);
 
-    let link = connect(&creds, &mixer, &bands, &tx).await?;
+    let link = connect(&creds, &mixer, &bands, &equalizer, &tx).await?;
     let inner = Arc::new(Inner {
         link: Mutex::new(Arc::new(link)),
         mixer,
         bands: Arc::clone(&bands),
+        equalizer,
         events: tx,
         creds,
     });
@@ -425,6 +447,7 @@ async fn connect(
     first_login: &Credentials,
     mixer: &Arc<SoftMixer>,
     bands: &Arc<Mutex<VisBands>>,
+    equalizer: &EqualizerControl,
     events: &flume::Sender<EngineEvent>,
 ) -> Result<Link> {
     let cache = build_cache()?;
@@ -445,13 +468,16 @@ async fn connect(
 
     let player = {
         let bands = Arc::clone(bands);
+        let equalizer = Arc::clone(equalizer);
         Player::new(
             player_config,
             session.clone(),
             mixer.get_soft_volume(),
             move || -> Box<dyn Sink> {
                 let real = backend(None, AudioFormat::default());
-                Box::new(VisualizationSink::new(real, Arc::clone(&bands), 44_100.0))
+                let visualizer =
+                    Box::new(VisualizationSink::new(real, Arc::clone(&bands), 44_100.0));
+                Box::new(EqualizerSink::new(visualizer, Arc::clone(&equalizer)))
             },
         )
     };

--- a/src/input/equalizer.rs
+++ b/src/input/equalizer.rs
@@ -1,0 +1,186 @@
+//! Input for the equalizer modal.
+
+use crate::*;
+
+pub(crate) fn handle_equalizer_key(app: &mut App, code: KeyCode) {
+    match code {
+        KeyCode::Esc | KeyCode::Char('e') => app.view.equalizer = None,
+        KeyCode::Left | KeyCode::Char('h') => move_band(app, -1),
+        KeyCode::Right | KeyCode::Char('l') => move_band(app, 1),
+        KeyCode::Up | KeyCode::Char('k') => adjust_selected_band(app, 1),
+        KeyCode::Down | KeyCode::Char('j') => adjust_selected_band(app, -1),
+        KeyCode::Char('0') => set_selected_band(app, 0),
+        KeyCode::Tab => cycle_preset(app, 1),
+        KeyCode::BackTab => cycle_preset(app, -1),
+        KeyCode::Char('r') => apply_preset(app, EqualizerPreset::Flat),
+        KeyCode::Char(' ') => {
+            let mut settings = app.transport.equalizer;
+            settings.enabled = !settings.enabled;
+            apply_settings(app, settings);
+        }
+        _ => {}
+    }
+}
+
+pub(crate) fn handle_equalizer_mouse(
+    app: &mut App,
+    out: &FrameOut,
+    event: crossterm::event::MouseEvent,
+) {
+    if !matches!(
+        event.kind,
+        MouseEventKind::Down(MouseButton::Left) | MouseEventKind::Drag(MouseButton::Left)
+    ) {
+        return;
+    }
+
+    let point_in = |rect: Rect| {
+        event.column >= rect.x
+            && event.column < rect.right()
+            && event.row >= rect.y
+            && event.row < rect.bottom()
+    };
+
+    if matches!(event.kind, MouseEventKind::Down(MouseButton::Left)) {
+        if out.hits.eq_toggle.is_some_and(point_in) {
+            let mut settings = app.transport.equalizer;
+            settings.enabled = !settings.enabled;
+            apply_settings(app, settings);
+            return;
+        }
+        if let Some(preset) = out
+            .hits
+            .eq_presets
+            .iter()
+            .find(|(_, rect)| point_in(*rect))
+            .map(|(preset, _)| *preset)
+        {
+            apply_preset(app, preset);
+            return;
+        }
+    }
+
+    if let Some(hit) = out.hits.eq_bands.iter().find(|hit| point_in(hit.rect)) {
+        if let Some(overlay) = app.view.equalizer.as_mut() {
+            overlay.selected_band = hit.band;
+        }
+        let gain = gain_from_pointer(*hit, event.column, event.row);
+        set_band(app, hit.band, gain);
+    }
+}
+
+fn apply_settings(app: &mut App, settings: EqualizerSettings) {
+    let settings = settings.normalized();
+    app.transport.equalizer = settings;
+    app.svc.engine.set_equalizer(settings);
+}
+
+fn apply_preset(app: &mut App, preset: EqualizerPreset) {
+    let mut settings = app.transport.equalizer;
+    settings.gains_db = preset.gains_db();
+    apply_settings(app, settings);
+}
+
+fn cycle_preset(app: &mut App, delta: isize) {
+    let current = EqualizerPreset::from_gains(&app.transport.equalizer.gains_db)
+        .and_then(|preset| EqualizerPreset::ALL.iter().position(|item| *item == preset));
+    let len = EqualizerPreset::ALL.len() as isize;
+    let next = match current {
+        Some(index) => (index as isize + delta).rem_euclid(len) as usize,
+        None if delta < 0 => EqualizerPreset::ALL.len() - 1,
+        None => 0,
+    };
+    apply_preset(app, EqualizerPreset::ALL[next]);
+}
+
+fn move_band(app: &mut App, delta: isize) {
+    if let Some(overlay) = app.view.equalizer.as_mut() {
+        overlay.selected_band =
+            (overlay.selected_band as isize + delta).rem_euclid(NUM_EQ_BANDS as isize) as usize;
+    }
+}
+
+fn adjust_selected_band(app: &mut App, delta: i8) {
+    let Some(band) = app
+        .view
+        .equalizer
+        .as_ref()
+        .map(|overlay| overlay.selected_band)
+    else {
+        return;
+    };
+    let gain = app.transport.equalizer.gains_db[band].saturating_add(delta);
+    set_band(app, band, gain);
+}
+
+fn set_selected_band(app: &mut App, gain: i8) {
+    let Some(band) = app
+        .view
+        .equalizer
+        .as_ref()
+        .map(|overlay| overlay.selected_band)
+    else {
+        return;
+    };
+    set_band(app, band, gain);
+}
+
+fn set_band(app: &mut App, band: usize, gain: i8) {
+    let mut settings = app.transport.equalizer;
+    settings.set_band(band, gain);
+    apply_settings(app, settings);
+}
+
+pub(crate) fn gain_from_pointer(hit: EqualizerBandHit, column: u16, row: u16) -> i8 {
+    let (offset, span) = if hit.vertical {
+        (
+            row.saturating_sub(hit.rect.y) as i32,
+            hit.rect.height.saturating_sub(1) as i32,
+        )
+    } else {
+        (
+            column.saturating_sub(hit.rect.x) as i32,
+            hit.rect.width.saturating_sub(1) as i32,
+        )
+    };
+    if span == 0 {
+        return 0;
+    }
+    let range = i32::from(MAX_EQ_GAIN_DB - MIN_EQ_GAIN_DB);
+    let step = (offset * range + span / 2) / span;
+    let gain = if hit.vertical {
+        i32::from(MAX_EQ_GAIN_DB) - step
+    } else {
+        i32::from(MIN_EQ_GAIN_DB) + step
+    };
+    gain.clamp(i32::from(MIN_EQ_GAIN_DB), i32::from(MAX_EQ_GAIN_DB)) as i8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vertical_pointer_maps_top_middle_and_bottom_to_gain_range() {
+        let hit = EqualizerBandHit {
+            band: 0,
+            rect: Rect::new(4, 10, 3, 25),
+            vertical: true,
+        };
+        assert_eq!(gain_from_pointer(hit, 5, 10), 12);
+        assert_eq!(gain_from_pointer(hit, 5, 22), 0);
+        assert_eq!(gain_from_pointer(hit, 5, 34), -12);
+    }
+
+    #[test]
+    fn horizontal_pointer_maps_left_middle_and_right_to_gain_range() {
+        let hit = EqualizerBandHit {
+            band: 3,
+            rect: Rect::new(10, 2, 25, 1),
+            vertical: false,
+        };
+        assert_eq!(gain_from_pointer(hit, 10, 2), -12);
+        assert_eq!(gain_from_pointer(hit, 22, 2), 0);
+        assert_eq!(gain_from_pointer(hit, 34, 2), 12);
+    }
+}

--- a/src/input/key.rs
+++ b/src/input/key.rs
@@ -31,6 +31,11 @@ pub(crate) fn handle_key(
         return false;
     }
 
+    if app.view.equalizer.is_some() {
+        handle_equalizer_key(app, code);
+        return false;
+    }
+
     // --- Search input mode captures everything ---
     if app.search.input_mode {
         match code {
@@ -70,6 +75,9 @@ pub(crate) fn handle_key(
     }
 
     match code {
+        KeyCode::Char('e') => {
+            app.view.equalizer = Some(EqualizerOverlay::default());
+        }
         KeyCode::Char('/') => {
             app.search.input_mode = true;
             app.search.clear();

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -8,11 +8,13 @@
 //! came from.
 
 mod actions;
+mod equalizer;
 mod key;
 mod media;
 mod mouse;
 
 pub(crate) use actions::*;
+pub(crate) use equalizer::*;
 pub(crate) use key::*;
 pub(crate) use media::*;
 pub(crate) use mouse::*;

--- a/src/input/mouse.rs
+++ b/src/input/mouse.rs
@@ -10,6 +10,13 @@ pub(crate) fn handle_mouse(
     m: crossterm::event::MouseEvent,
     chans: &UiChannels,
 ) -> bool {
+    // The equalizer is modal: its own hit rects get first refusal and every
+    // other mouse event is swallowed so nothing hidden behind it moves.
+    if app.view.equalizer.is_some() {
+        handle_equalizer_mouse(app, out, m);
+        return false;
+    }
+
     if matches!(
         m.kind,
         MouseEventKind::Down(MouseButton::Left) | MouseEventKind::Drag(MouseButton::Left)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 //! myx — the fully-wired terminal Spotify player.
 //!
 //! librespot streaming engine + Web API (your own client id) + album-art-reactive
-//! theming with cross-fades + live FFT visualizer, in noodle's visual language.
+//! theming with cross-fades + live equalizer/FFT visualizer, in noodle's visual language.
 //! Multi-section library (playlists / liked / albums / artists), shuffle, repeat,
 //! and a live queue view.
 
@@ -44,7 +44,10 @@ use api::*;
 use app::*;
 use input::*;
 use myx::anim::ThemeFade;
-use myx::audio::NUM_BANDS;
+use myx::audio::{
+    EqualizerPreset, EqualizerSettings, EQ_FREQUENCIES_HZ, MAX_EQ_GAIN_DB, MIN_EQ_GAIN_DB,
+    NUM_BANDS, NUM_EQ_BANDS,
+};
 use myx::components::{gradient_line, gradient_progress, left_bar_block};
 use myx::cover::Cover;
 use myx::engine::{self, Engine, EngineEvent};
@@ -331,6 +334,8 @@ async fn boot(
     )
     .await?
     .context("start engine")?;
+    let equalizer = saved.equalizer.normalized();
+    engine.set_equalizer(equalizer);
 
     let webapi = Arc::new(Mutex::new(webapi));
 
@@ -432,6 +437,7 @@ async fn boot(
             playback_started: startup_uri.is_some(),
             source,
             source_name,
+            equalizer,
         },
         search: SearchState {
             input_mode: false,
@@ -446,6 +452,7 @@ async fn boot(
             lyrics: Vec::new(),
             lyrics_synced: false,
             actions: None,
+            equalizer: None,
         },
         session: SessionState {
             restore_uri,
@@ -566,7 +573,7 @@ async fn run_ui(
     // Nothing is on screen yet, so the first tick must draw.
     let mut dirty = true;
     let mut last_layout = (app.view.mode, app.view.zen);
-    let mut overlay_open = app.view.actions.is_some();
+    let mut action_overlay_open = app.view.actions.is_some();
     // What the renderer writes. Lives across frames: the hit rects are what the
     // mouse handler reads between draws, and `lib_offset` is fed back into the
     // next frame's sticky-viewport calculation.
@@ -658,10 +665,10 @@ async fn run_ui(
                 // pixels, so the cover has to be sent again once it closes.
                 // Opening one must not wipe: the image would be redrawn a frame
                 // later, back on top of the popup.
-                let overlay = app.view.actions.is_some();
-                if overlay != overlay_open {
-                    overlay_open = overlay;
-                    if !overlay {
+                let action_overlay = app.view.actions.is_some();
+                if action_overlay != action_overlay_open {
+                    action_overlay_open = action_overlay;
+                    if !action_overlay {
                         app.art_repaint = ArtRepaint::Wipe;
                     }
                     dirty = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -573,7 +573,7 @@ async fn run_ui(
     // Nothing is on screen yet, so the first tick must draw.
     let mut dirty = true;
     let mut last_layout = (app.view.mode, app.view.zen);
-    let mut action_overlay_open = app.view.actions.is_some();
+    let mut overlay_open = app.view.actions.is_some();
     // What the renderer writes. Lives across frames: the hit rects are what the
     // mouse handler reads between draws, and `lib_offset` is fed back into the
     // next frame's sticky-viewport calculation.
@@ -665,10 +665,10 @@ async fn run_ui(
                 // pixels, so the cover has to be sent again once it closes.
                 // Opening one must not wipe: the image would be redrawn a frame
                 // later, back on top of the popup.
-                let action_overlay = app.view.actions.is_some();
-                if action_overlay != action_overlay_open {
-                    action_overlay_open = action_overlay;
-                    if !action_overlay {
+                let overlay = app.view.actions.is_some();
+                if overlay != overlay_open {
+                    overlay_open = overlay;
+                    if !overlay {
                         app.art_repaint = ArtRepaint::Wipe;
                     }
                     dirty = true;

--- a/src/ui/equalizer.rs
+++ b/src/ui/equalizer.rs
@@ -5,9 +5,10 @@ use crate::*;
 
 const NORMAL_MIN_WIDTH: u16 = 62;
 const NORMAL_MIN_HEIGHT: u16 = 16;
-const ART_GAP_X: u16 = 2;
-/// Cover metadata occupies the three rows below the art plus one gap row.
-const ART_GAP_BELOW: u16 = 4;
+const NOW_PLAYING_BOTTOM_ROWS: u16 = 9;
+const NOW_PLAYING_TOP_INSET: u16 = 3;
+const MAX_ART_HEIGHT: u16 = 14;
+const ART_METADATA_ROWS: u16 = 4;
 
 pub(crate) fn render_equalizer_overlay(
     f: &mut Frame,
@@ -19,10 +20,10 @@ pub(crate) fn render_equalizer_overlay(
     let Some(overlay) = app.view.equalizer.as_ref() else {
         return;
     };
-    let art = (app.view.mode == RightView::NowPlaying)
-        .then(|| nowplaying_art_rect(app, area))
-        .flatten();
-    let rect = equalizer_rect(area, art);
+    out.hits.eq_toggle = None;
+    out.hits.eq_presets.clear();
+    out.hits.eq_bands.clear();
+    let rect = equalizer_rect(area, app.view.mode == RightView::NowPlaying);
 
     f.render_widget(Clear, rect);
     f.render_widget(Block::default().style(theme.element()), rect);
@@ -42,60 +43,42 @@ pub(crate) fn render_equalizer_overlay(
     force_area(f, rect);
 }
 
-/// Prefer the free area below the cover (replacing the visualizer while the
-/// editor is open). Small terminals fall back to the largest non-overlapping
-/// side and automatically use the compact controls.
-fn equalizer_rect(area: Rect, art: Option<Rect>) -> Rect {
-    let desired_width = (area.width.saturating_mul(9) / 10)
+/// Prefer the free area below the complete cover/metadata group, replacing the
+/// visualizer while the editor is open. The constants mirror the Now Playing
+/// layout without coupling this feature to its renderer; that keeps the two
+/// independently mergeable. Short panes naturally select the compact controls.
+fn equalizer_rect(area: Rect, reserve_now_playing: bool) -> Rect {
+    let region = if reserve_now_playing {
+        let top_height = area
+            .height
+            .saturating_sub(NOW_PLAYING_BOTTOM_ROWS)
+            .saturating_sub(NOW_PLAYING_TOP_INSET);
+        let art_height = top_height
+            .saturating_sub(ART_METADATA_ROWS)
+            .clamp(3, MAX_ART_HEIGHT);
+        let group_height = art_height.saturating_add(ART_METADATA_ROWS);
+        let group_y = area
+            .y
+            .saturating_add(NOW_PLAYING_TOP_INSET)
+            .saturating_add(top_height.saturating_sub(group_height) / 2);
+        let below_y = group_y.saturating_add(group_height).min(area.bottom());
+        Rect::new(area.x, below_y, area.width, area.bottom() - below_y)
+    } else {
+        area
+    };
+
+    let width = (region.width.saturating_mul(9) / 10)
         .clamp(1, 100)
-        .min(area.width);
-    let desired_height = (area.height.saturating_mul(9) / 10)
+        .min(region.width);
+    let height = (region.height.saturating_mul(9) / 10)
         .clamp(1, 24)
-        .min(area.height);
-    let fit = |region: Rect| {
-        let width = desired_width.min(region.width);
-        let height = desired_height.min(region.height);
-        Rect::new(
-            region.x + region.width.saturating_sub(width) / 2,
-            region.y + region.height.saturating_sub(height) / 2,
-            width,
-            height,
-        )
-    };
-
-    let Some(art) = art.filter(|art| art.intersects(area)) else {
-        return fit(area);
-    };
-    let below_y = art
-        .bottom()
-        .saturating_add(ART_GAP_BELOW)
-        .clamp(area.y, area.bottom());
-    let above_bottom = art.y.clamp(area.y, area.bottom());
-    let left_right = art.x.saturating_sub(ART_GAP_X).clamp(area.x, area.right());
-    let right_x = art
-        .right()
-        .saturating_add(ART_GAP_X)
-        .clamp(area.x, area.right());
-    let regions = [
-        Rect::new(area.x, below_y, area.width, area.bottom() - below_y),
-        Rect::new(area.x, area.y, left_right - area.x, area.height),
-        Rect::new(right_x, area.y, area.right() - right_x, area.height),
-        Rect::new(area.x, area.y, area.width, above_bottom - area.y),
-    ];
-
-    if let Some(region) = regions
-        .iter()
-        .copied()
-        .find(|region| region.width >= NORMAL_MIN_WIDTH && region.height >= NORMAL_MIN_HEIGHT)
-    {
-        return fit(region);
-    }
-
-    regions
-        .into_iter()
-        .filter(|region| region.width > 0 && region.height > 0)
-        .max_by_key(|region| u32::from(region.width) * u32::from(region.height))
-        .map_or_else(|| fit(area), fit)
+        .min(region.height);
+    Rect::new(
+        region.x + region.width.saturating_sub(width) / 2,
+        region.y + region.height.saturating_sub(height) / 2,
+        width,
+        height,
+    )
 }
 
 fn render_header(f: &mut Frame, app: &App, out: &mut FrameOut, theme: Theme, area: Rect) {
@@ -395,10 +378,10 @@ mod tests {
     fn equalizer_sits_below_the_cover_when_the_pane_has_room() {
         let pane = Rect::new(80, 4, 180, 54);
         let art = Rect::new(154, 19, 32, 14);
-        let equalizer = equalizer_rect(pane, Some(art));
+        let equalizer = equalizer_rect(pane, true);
 
         assert!(!equalizer.intersects(art));
-        assert!(equalizer.y >= art.bottom() + ART_GAP_BELOW);
+        assert!(equalizer.y >= art.bottom() + ART_METADATA_ROWS);
         assert!(equalizer.width >= NORMAL_MIN_WIDTH);
         assert!(equalizer.height >= NORMAL_MIN_HEIGHT);
     }
@@ -406,8 +389,8 @@ mod tests {
     #[test]
     fn compact_equalizer_still_avoids_art_on_a_small_pane() {
         let pane = Rect::new(0, 0, 40, 25);
-        let art = Rect::new(10, 10, 20, 15);
-        let equalizer = equalizer_rect(pane, Some(art));
+        let art = Rect::new(10, 3, 20, 9);
+        let equalizer = equalizer_rect(pane, true);
 
         assert!(!equalizer.intersects(art));
         assert!(equalizer.width > 0);

--- a/src/ui/equalizer.rs
+++ b/src/ui/equalizer.rs
@@ -1,0 +1,416 @@
+//! The interactive ten-band equalizer overlay.
+
+use super::*;
+use crate::*;
+
+const NORMAL_MIN_WIDTH: u16 = 62;
+const NORMAL_MIN_HEIGHT: u16 = 16;
+const ART_GAP_X: u16 = 2;
+/// Cover metadata occupies the three rows below the art plus one gap row.
+const ART_GAP_BELOW: u16 = 4;
+
+pub(crate) fn render_equalizer_overlay(
+    f: &mut Frame,
+    app: &App,
+    out: &mut FrameOut,
+    theme: Theme,
+    area: Rect,
+) {
+    let Some(overlay) = app.view.equalizer.as_ref() else {
+        return;
+    };
+    let art = (app.view.mode == RightView::NowPlaying)
+        .then(|| nowplaying_art_rect(app, area))
+        .flatten();
+    let rect = equalizer_rect(area, art);
+
+    f.render_widget(Clear, rect);
+    f.render_widget(Block::default().style(theme.element()), rect);
+    let inner = rect.inner(Margin::new(2, 1));
+    if inner.width == 0 || inner.height == 0 {
+        force_area(f, rect);
+        return;
+    }
+
+    render_header(f, app, out, theme, inner);
+    if rect.width >= NORMAL_MIN_WIDTH && rect.height >= NORMAL_MIN_HEIGHT {
+        render_presets(f, app, out, theme, inner);
+        render_bands(f, app, out, theme, inner);
+    } else {
+        render_compact(f, app, out, theme, inner, overlay.selected_band);
+    }
+    force_area(f, rect);
+}
+
+/// Prefer the free area below the cover (replacing the visualizer while the
+/// editor is open). Small terminals fall back to the largest non-overlapping
+/// side and automatically use the compact controls.
+fn equalizer_rect(area: Rect, art: Option<Rect>) -> Rect {
+    let desired_width = (area.width.saturating_mul(9) / 10)
+        .clamp(1, 100)
+        .min(area.width);
+    let desired_height = (area.height.saturating_mul(9) / 10)
+        .clamp(1, 24)
+        .min(area.height);
+    let fit = |region: Rect| {
+        let width = desired_width.min(region.width);
+        let height = desired_height.min(region.height);
+        Rect::new(
+            region.x + region.width.saturating_sub(width) / 2,
+            region.y + region.height.saturating_sub(height) / 2,
+            width,
+            height,
+        )
+    };
+
+    let Some(art) = art.filter(|art| art.intersects(area)) else {
+        return fit(area);
+    };
+    let below_y = art
+        .bottom()
+        .saturating_add(ART_GAP_BELOW)
+        .clamp(area.y, area.bottom());
+    let above_bottom = art.y.clamp(area.y, area.bottom());
+    let left_right = art.x.saturating_sub(ART_GAP_X).clamp(area.x, area.right());
+    let right_x = art
+        .right()
+        .saturating_add(ART_GAP_X)
+        .clamp(area.x, area.right());
+    let regions = [
+        Rect::new(area.x, below_y, area.width, area.bottom() - below_y),
+        Rect::new(area.x, area.y, left_right - area.x, area.height),
+        Rect::new(right_x, area.y, area.right() - right_x, area.height),
+        Rect::new(area.x, area.y, area.width, above_bottom - area.y),
+    ];
+
+    if let Some(region) = regions
+        .iter()
+        .copied()
+        .find(|region| region.width >= NORMAL_MIN_WIDTH && region.height >= NORMAL_MIN_HEIGHT)
+    {
+        return fit(region);
+    }
+
+    regions
+        .into_iter()
+        .filter(|region| region.width > 0 && region.height > 0)
+        .max_by_key(|region| u32::from(region.width) * u32::from(region.height))
+        .map_or_else(|| fit(area), fit)
+}
+
+fn render_header(f: &mut Frame, app: &App, out: &mut FrameOut, theme: Theme, area: Rect) {
+    let row = Rect::new(area.x, area.y, area.width, 1);
+    f.render_widget(Paragraph::new("EQUALIZER").style(theme.heading()), row);
+
+    let toggle = if app.transport.equalizer.enabled {
+        " ON "
+    } else {
+        " BYPASS "
+    };
+    let toggle_width = toggle.chars().count() as u16;
+    let toggle_x = row.right().saturating_sub(toggle_width).max(row.x);
+    let toggle_rect = Rect::new(toggle_x, row.y, row.right().saturating_sub(toggle_x), 1);
+    let toggle_style = if app.transport.equalizer.enabled {
+        Style::default()
+            .bg(theme.success.into())
+            .fg(theme.background.into())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .bg(theme.border_subtle.into())
+            .fg(theme.text.into())
+            .add_modifier(Modifier::BOLD)
+    };
+    f.render_widget(Paragraph::new(toggle).style(toggle_style), toggle_rect);
+    out.hits.eq_toggle = Some(toggle_rect);
+
+    let preset = EqualizerPreset::from_gains(&app.transport.equalizer.gains_db)
+        .map(EqualizerPreset::label)
+        .unwrap_or("Custom");
+    let preamp = app.transport.equalizer.auto_preamp_db();
+    let info = format!("{preset}  ·  AUTO {preamp:+.1} dB");
+    let info_right = toggle_rect.x.saturating_sub(2);
+    let info_x = row.x.saturating_add(11).min(info_right);
+    let info_width = info
+        .chars()
+        .count()
+        .min(info_right.saturating_sub(info_x) as usize) as u16;
+    if info_width > 0 {
+        f.render_widget(
+            Paragraph::new(truncate(&info, info_width as usize))
+                .style(theme.muted())
+                .alignment(Alignment::Right),
+            Rect::new(info_x, row.y, info_right.saturating_sub(info_x), 1),
+        );
+    }
+}
+
+fn render_presets(f: &mut Frame, app: &App, out: &mut FrameOut, theme: Theme, area: Rect) {
+    if area.height < 3 {
+        return;
+    }
+    let current = EqualizerPreset::from_gains(&app.transport.equalizer.gains_db);
+    let widths: Vec<u16> = EqualizerPreset::ALL
+        .iter()
+        .map(|preset| preset.short_label().chars().count() as u16 + 2)
+        .collect();
+    let total = widths.iter().sum::<u16>() + EqualizerPreset::ALL.len() as u16 - 1;
+    let mut x = area.x + area.width.saturating_sub(total) / 2;
+    for (preset, width) in EqualizerPreset::ALL.into_iter().zip(widths) {
+        let rect = Rect::new(x, area.y + 2, width, 1);
+        let active = current == Some(preset);
+        let style = if active {
+            Style::default()
+                .bg(theme.primary.into())
+                .fg(theme.background.into())
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+                .bg(theme.border_dimmest.into())
+                .fg(theme.text_muted.into())
+        };
+        f.render_widget(
+            Paragraph::new(format!(" {} ", preset.short_label())).style(style),
+            rect,
+        );
+        out.hits.eq_presets.push((preset, rect));
+        x = x.saturating_add(width + 1);
+    }
+}
+
+fn render_bands(f: &mut Frame, app: &App, out: &mut FrameOut, theme: Theme, area: Rect) {
+    let selected = app
+        .view
+        .equalizer
+        .as_ref()
+        .map_or(0, |overlay| overlay.selected_band.min(NUM_EQ_BANDS - 1));
+    let track_top = area.y + 5;
+    let hint_y = area.bottom().saturating_sub(1);
+    let label_y = hint_y.saturating_sub(2);
+    let track_height = label_y.saturating_sub(track_top).max(1);
+    let column_width = (area.width / NUM_EQ_BANDS as u16).max(1);
+    let content_width = column_width * NUM_EQ_BANDS as u16;
+    let start_x = area.x + area.width.saturating_sub(content_width) / 2;
+
+    for (band, &frequency) in EQ_FREQUENCIES_HZ.iter().enumerate() {
+        let column = Rect::new(
+            start_x + band as u16 * column_width,
+            track_top,
+            column_width,
+            track_height,
+        );
+        let gain = app.transport.equalizer.gains_db[band];
+        f.render_widget(
+            Paragraph::new(format!("{gain:+}"))
+                .alignment(Alignment::Center)
+                .style(if band == selected {
+                    theme.heading()
+                } else {
+                    theme.muted()
+                }),
+            Rect::new(column.x, track_top.saturating_sub(1), column.width, 1),
+        );
+
+        let rail_x = column.x + column.width / 2;
+        let knob_y = gain_to_row(gain, track_top, track_height);
+        let zero_y = gain_to_row(0, track_top, track_height);
+        for y in track_top..track_top.saturating_add(track_height) {
+            let between = y >= knob_y.min(zero_y) && y <= knob_y.max(zero_y);
+            let color = if between {
+                if band == selected {
+                    theme.primary
+                } else {
+                    theme.success
+                }
+            } else {
+                theme.border_dimmest
+            };
+            f.render_widget(
+                Paragraph::new("│").style(Style::default().fg(color.into())),
+                Rect::new(rail_x, y, 1, 1),
+            );
+        }
+        let knob_width = 3.min(column.width);
+        let knob_x = rail_x.saturating_sub(knob_width / 2).max(column.x);
+        f.render_widget(
+            Paragraph::new("━".repeat(knob_width as usize)).style(
+                Style::default()
+                    .fg(if band == selected {
+                        theme.accent.into()
+                    } else {
+                        theme.text.into()
+                    })
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Rect::new(knob_x, knob_y, knob_width, 1),
+        );
+        f.render_widget(
+            Paragraph::new(format_frequency(frequency))
+                .style(if band == selected {
+                    theme.heading()
+                } else {
+                    theme.muted()
+                })
+                .alignment(Alignment::Center),
+            Rect::new(column.x, label_y, column.width, 1),
+        );
+        out.hits.eq_bands.push(EqualizerBandHit {
+            band,
+            rect: column,
+            vertical: true,
+        });
+    }
+
+    render_hints(f, theme, Rect::new(area.x, hint_y, area.width, 1));
+}
+
+fn render_compact(
+    f: &mut Frame,
+    app: &App,
+    out: &mut FrameOut,
+    theme: Theme,
+    area: Rect,
+    selected_band: usize,
+) {
+    if area.height < 3 {
+        return;
+    }
+    let band = selected_band.min(NUM_EQ_BANDS - 1);
+    let preset = EqualizerPreset::from_gains(&app.transport.equalizer.gains_db)
+        .map(EqualizerPreset::label)
+        .unwrap_or("Custom");
+    f.render_widget(
+        Paragraph::new(format!("Preset: {preset}  ·  Tab to change")).style(theme.muted()),
+        Rect::new(area.x, area.y + 2, area.width, 1),
+    );
+    if area.height < 7 {
+        return;
+    }
+    let gain = app.transport.equalizer.gains_db[band];
+    let title_y = area.y + 4;
+    f.render_widget(
+        Paragraph::new(format!(
+            "{} Hz  {gain:+} dB",
+            format_frequency(EQ_FREQUENCIES_HZ[band])
+        ))
+        .style(theme.heading())
+        .alignment(Alignment::Center),
+        Rect::new(area.x, title_y, area.width, 1),
+    );
+
+    let track_width = area.width.saturating_sub(8).max(1);
+    let track = Rect::new(
+        area.x + area.width.saturating_sub(track_width) / 2,
+        title_y + 2,
+        track_width,
+        1,
+    );
+    let knob = gain_to_column(gain, track.x, track.width);
+    for x in track.x..track.right() {
+        let color = if x <= knob {
+            theme.primary
+        } else {
+            theme.border_dimmest
+        };
+        f.render_widget(
+            Paragraph::new("─").style(Style::default().fg(color.into())),
+            Rect::new(x, track.y, 1, 1),
+        );
+    }
+    f.render_widget(
+        Paragraph::new("◆").style(Style::default().fg(theme.accent.into())),
+        Rect::new(knob, track.y, 1, 1),
+    );
+    out.hits.eq_bands.push(EqualizerBandHit {
+        band,
+        rect: track,
+        vertical: false,
+    });
+    if area.height >= 9 {
+        render_hints(
+            f,
+            theme,
+            Rect::new(area.x, area.bottom().saturating_sub(1), area.width, 1),
+        );
+    }
+}
+
+fn render_hints(f: &mut Frame, theme: Theme, area: Rect) {
+    f.render_widget(
+        Paragraph::new("Tab preset  ←→ band  ↑↓ gain  Space bypass  e/Esc close")
+            .style(theme.muted())
+            .alignment(Alignment::Center),
+        area,
+    );
+}
+
+fn gain_to_row(gain: i8, top: u16, height: u16) -> u16 {
+    if height <= 1 {
+        return top;
+    }
+    let range = i32::from(MAX_EQ_GAIN_DB - MIN_EQ_GAIN_DB);
+    let from_top = i32::from(MAX_EQ_GAIN_DB - gain.clamp(MIN_EQ_GAIN_DB, MAX_EQ_GAIN_DB));
+    top + ((from_top * i32::from(height - 1) + range / 2) / range) as u16
+}
+
+fn gain_to_column(gain: i8, left: u16, width: u16) -> u16 {
+    if width <= 1 {
+        return left;
+    }
+    let range = i32::from(MAX_EQ_GAIN_DB - MIN_EQ_GAIN_DB);
+    let offset = i32::from(gain.clamp(MIN_EQ_GAIN_DB, MAX_EQ_GAIN_DB) - MIN_EQ_GAIN_DB);
+    left + ((offset * i32::from(width - 1) + range / 2) / range) as u16
+}
+
+fn format_frequency(frequency: f64) -> String {
+    if frequency >= 1_000.0 {
+        format!("{}k", (frequency / 1_000.0) as u16)
+    } else {
+        (frequency as u16).to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gain_positions_cover_both_ends_and_the_midpoint() {
+        assert_eq!(gain_to_row(12, 5, 25), 5);
+        assert_eq!(gain_to_row(0, 5, 25), 17);
+        assert_eq!(gain_to_row(-12, 5, 25), 29);
+        assert_eq!(gain_to_column(-12, 10, 25), 10);
+        assert_eq!(gain_to_column(0, 10, 25), 22);
+        assert_eq!(gain_to_column(12, 10, 25), 34);
+    }
+
+    #[test]
+    fn frequency_labels_stay_compact() {
+        assert_eq!(format_frequency(31.0), "31");
+        assert_eq!(format_frequency(1_000.0), "1k");
+        assert_eq!(format_frequency(16_000.0), "16k");
+    }
+
+    #[test]
+    fn equalizer_sits_below_the_cover_when_the_pane_has_room() {
+        let pane = Rect::new(80, 4, 180, 54);
+        let art = Rect::new(154, 19, 32, 14);
+        let equalizer = equalizer_rect(pane, Some(art));
+
+        assert!(!equalizer.intersects(art));
+        assert!(equalizer.y >= art.bottom() + ART_GAP_BELOW);
+        assert!(equalizer.width >= NORMAL_MIN_WIDTH);
+        assert!(equalizer.height >= NORMAL_MIN_HEIGHT);
+    }
+
+    #[test]
+    fn compact_equalizer_still_avoids_art_on_a_small_pane() {
+        let pane = Rect::new(0, 0, 40, 25);
+        let art = Rect::new(10, 10, 20, 15);
+        let equalizer = equalizer_rect(pane, Some(art));
+
+        assert!(!equalizer.intersects(art));
+        assert!(equalizer.width > 0);
+        assert!(equalizer.height > 0);
+    }
+}

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -36,6 +36,7 @@ pub(crate) fn render_footer(f: &mut Frame, app: &App, theme: Theme, area: Rect) 
             lbl(" shuffle   "),
         ),
         (false, key("a"), lbl(" actions   ")),
+        (false, key("e"), lbl(" eq   ")),
         (
             false,
             Span::styled("z", Style::default().fg(on(app.view.zen).into())),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -25,9 +25,6 @@ pub(crate) use visualizer::*;
 use crate::*;
 
 pub(crate) fn render(f: &mut Frame, app: &App, out: &mut FrameOut, repaint: ArtRepaint) {
-    out.hits.eq_toggle = None;
-    out.hits.eq_presets.clear();
-    out.hits.eq_bands.clear();
     let theme = app.theme.displayed;
     let area = f.area();
     f.render_widget(Block::default().style(theme.base()), area);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@
 //! nothing here mutates application state. One module per screen, so the file
 //! to open is the one named after the thing on screen.
 
+mod equalizer;
 mod footer;
 mod library;
 mod lyrics;
@@ -12,6 +13,7 @@ mod overlay;
 mod queue;
 mod visualizer;
 
+pub(crate) use equalizer::*;
 pub(crate) use footer::*;
 pub(crate) use library::*;
 pub(crate) use lyrics::*;
@@ -23,6 +25,9 @@ pub(crate) use visualizer::*;
 use crate::*;
 
 pub(crate) fn render(f: &mut Frame, app: &App, out: &mut FrameOut, repaint: ArtRepaint) {
+    out.hits.eq_toggle = None;
+    out.hits.eq_presets.clear();
+    out.hits.eq_bands.clear();
     let theme = app.theme.displayed;
     let area = f.area();
     f.render_widget(Block::default().style(theme.base()), area);
@@ -111,6 +116,10 @@ pub(crate) fn render(f: &mut Frame, app: &App, out: &mut FrameOut, repaint: ArtR
 
     if app.view.actions.is_some() {
         render_actions_overlay(f, app, theme, area);
+    } else if app.view.equalizer.is_some() {
+        // Keep album art visible: the editor lives in the active pane and
+        // positions itself in free space around the cover.
+        render_equalizer_overlay(f, app, out, theme, right);
     }
 }
 

--- a/src/ui/nowplaying.rs
+++ b/src/ui/nowplaying.rs
@@ -3,6 +3,48 @@
 use super::*;
 use crate::*;
 
+fn nowplaying_regions(area: Rect) -> (Rect, Rect) {
+    let chunks = Layout::vertical([
+        Constraint::Min(6),    // art + text
+        Constraint::Length(7), // spectrum
+        Constraint::Length(2), // breathing room (lifts the spectrum up)
+    ])
+    .split(area);
+    let top = Rect {
+        x: chunks[0].x,
+        y: chunks[0].y + 3,
+        width: chunks[0].width,
+        height: chunks[0].height.saturating_sub(3),
+    };
+    (top, chunks[1])
+}
+
+/// Album-art footprint for the current Now Playing layout. The equalizer uses
+/// the same calculation so its text-cell popup never clips the inline image.
+pub(crate) fn nowplaying_art_rect(app: &App, area: Rect) -> Option<Rect> {
+    app.playback.now.as_ref()?;
+    let (top, _) = nowplaying_regions(area);
+
+    let font = app.svc.picker.font_size();
+    let fw = font.width.max(1) as u32;
+    let fh = font.height.max(1) as u32;
+    let avail_h = top.height.saturating_sub(4);
+    let mut art_h = avail_h.clamp(3, 14);
+    let mut art_w = (art_h as u32 * fh / fw) as u16;
+    if art_w > top.width {
+        art_w = top.width;
+        art_h = (art_w as u32 * fw / fh) as u16;
+    }
+
+    let group_h = art_h + 4;
+    Some(Rect {
+        x: top.x + top.width.saturating_sub(art_w) / 2,
+        y: top.y + top.height.saturating_sub(group_h) / 2,
+        width: art_w,
+        height: art_h,
+    })
+}
+
 /// View ①: album art with track details directly beneath — centered as a group.
 pub(crate) fn render_nowplaying_view(
     f: &mut Frame,
@@ -23,47 +65,9 @@ pub(crate) fn render_nowplaying_view(
 
     // Split: album art + track info on top, a compact spectrum below, lifted a
     // little off the bottom.
-    let chunks = Layout::vertical([
-        Constraint::Min(6),    // art + text
-        Constraint::Length(7), // spectrum
-        Constraint::Length(2), // breathing room (lifts the spectrum up)
-    ])
-    .split(area);
-    let top = chunks[0];
-    // Push the art + info group down a little from the top.
-    let top = Rect {
-        x: top.x,
-        y: top.y + 3,
-        width: top.width,
-        height: top.height.saturating_sub(3),
-    };
-    let viz_area = chunks[1];
-
-    // Derive the cover's cell footprint from the terminal's font aspect so a
-    // square image renders square (and our centering math is exact).
-    let font = app.svc.picker.font_size();
-    let fw = font.width.max(1) as u32;
-    let fh = font.height.max(1) as u32;
-
-    // Reserve 3 rows for text (+1 gap). Cap the art so the group stays compact.
-    let avail_h = top.height.saturating_sub(4);
-    let mut art_h = avail_h.clamp(3, 14);
-    // Square image width in cells for this height: w = h * fh / fw.
-    let mut art_w = (art_h as u32 * fh / fw) as u16;
-    if art_w > top.width {
-        art_w = top.width;
-        art_h = (art_w as u32 * fw / fh) as u16;
-    }
-
-    let group_h = art_h + 4; // art + gap + title + artist + album
-    let art_y = top.y + top.height.saturating_sub(group_h) / 2;
-    let art_x = top.x + top.width.saturating_sub(art_w) / 2;
-    let art_rect = Rect {
-        x: art_x,
-        y: art_y,
-        width: art_w,
-        height: art_h,
-    };
+    let (top, viz_area) = nowplaying_regions(area);
+    let art_rect = nowplaying_art_rect(app, area).expect("current track checked above");
+    let art_h = art_rect.height;
 
     match app.playback.now.as_ref().and_then(|n| n.cover.as_ref()) {
         _ if repaint == ArtRepaint::Wipe => wipe_area(f, art_rect),

--- a/src/ui/nowplaying.rs
+++ b/src/ui/nowplaying.rs
@@ -3,48 +3,6 @@
 use super::*;
 use crate::*;
 
-fn nowplaying_regions(area: Rect) -> (Rect, Rect) {
-    let chunks = Layout::vertical([
-        Constraint::Min(6),    // art + text
-        Constraint::Length(7), // spectrum
-        Constraint::Length(2), // breathing room (lifts the spectrum up)
-    ])
-    .split(area);
-    let top = Rect {
-        x: chunks[0].x,
-        y: chunks[0].y + 3,
-        width: chunks[0].width,
-        height: chunks[0].height.saturating_sub(3),
-    };
-    (top, chunks[1])
-}
-
-/// Album-art footprint for the current Now Playing layout. The equalizer uses
-/// the same calculation so its text-cell popup never clips the inline image.
-pub(crate) fn nowplaying_art_rect(app: &App, area: Rect) -> Option<Rect> {
-    app.playback.now.as_ref()?;
-    let (top, _) = nowplaying_regions(area);
-
-    let font = app.svc.picker.font_size();
-    let fw = font.width.max(1) as u32;
-    let fh = font.height.max(1) as u32;
-    let avail_h = top.height.saturating_sub(4);
-    let mut art_h = avail_h.clamp(3, 14);
-    let mut art_w = (art_h as u32 * fh / fw) as u16;
-    if art_w > top.width {
-        art_w = top.width;
-        art_h = (art_w as u32 * fw / fh) as u16;
-    }
-
-    let group_h = art_h + 4;
-    Some(Rect {
-        x: top.x + top.width.saturating_sub(art_w) / 2,
-        y: top.y + top.height.saturating_sub(group_h) / 2,
-        width: art_w,
-        height: art_h,
-    })
-}
-
 /// View ①: album art with track details directly beneath — centered as a group.
 pub(crate) fn render_nowplaying_view(
     f: &mut Frame,
@@ -65,9 +23,47 @@ pub(crate) fn render_nowplaying_view(
 
     // Split: album art + track info on top, a compact spectrum below, lifted a
     // little off the bottom.
-    let (top, viz_area) = nowplaying_regions(area);
-    let art_rect = nowplaying_art_rect(app, area).expect("current track checked above");
-    let art_h = art_rect.height;
+    let chunks = Layout::vertical([
+        Constraint::Min(6),    // art + text
+        Constraint::Length(7), // spectrum
+        Constraint::Length(2), // breathing room (lifts the spectrum up)
+    ])
+    .split(area);
+    let top = chunks[0];
+    // Push the art + info group down a little from the top.
+    let top = Rect {
+        x: top.x,
+        y: top.y + 3,
+        width: top.width,
+        height: top.height.saturating_sub(3),
+    };
+    let viz_area = chunks[1];
+
+    // Derive the cover's cell footprint from the terminal's font aspect so a
+    // square image renders square (and our centering math is exact).
+    let font = app.svc.picker.font_size();
+    let fw = font.width.max(1) as u32;
+    let fh = font.height.max(1) as u32;
+
+    // Reserve 3 rows for text (+1 gap). Cap the art so the group stays compact.
+    let avail_h = top.height.saturating_sub(4);
+    let mut art_h = avail_h.clamp(3, 14);
+    // Square image width in cells for this height: w = h * fh / fw.
+    let mut art_w = (art_h as u32 * fh / fw) as u16;
+    if art_w > top.width {
+        art_w = top.width;
+        art_h = (art_w as u32 * fw / fh) as u16;
+    }
+
+    let group_h = art_h + 4; // art + gap + title + artist + album
+    let art_y = top.y + top.height.saturating_sub(group_h) / 2;
+    let art_x = top.x + top.width.saturating_sub(art_w) / 2;
+    let art_rect = Rect {
+        x: art_x,
+        y: art_y,
+        width: art_w,
+        height: art_h,
+    };
 
     match app.playback.now.as_ref().and_then(|n| n.cover.as_ref()) {
         _ if repaint == ArtRepaint::Wipe => wipe_area(f, art_rect),


### PR DESCRIPTION
## Summary
- add a live ten-band stereo equalizer to the PCM pipeline before visualization and playback
- provide Flat, Bass Boost, Rock, Jazz, Vocal, Electronic, and Treble Boost presets plus per-band custom gain controls
- apply automatic response-aware headroom to reduce digital clipping on boosted curves
- add a keyboard- and mouse-controlled equalizer editor with a compact small-terminal fallback
- keep album art fully visible by placing the editor below the complete cover/metadata group
- persist the enabled state and complete curve across launches, while remaining backward-compatible with older state files
- document the controls and internal modules

Press `e` to open the editor. Use `Tab` / `Shift+Tab` for presets, arrow keys for band/gain selection, `Space` for bypass comparison, and `e` or `Esc` to close. Presets and sliders also support mouse input.

This PR is independent of #43 and does not include its cover-repaint commit. Its final tree was also merge-simulated with #43: Git merged all shared files automatically, and the combined result passed the full verification suite.

## Testing
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (229 passed; 6 ignored live/benchmark tests)
- `cargo check --no-default-features --features mxc`
- `git diff --check`
- combined #43 + #44 merge tree: no conflicts; 230 tests passed plus the same format, Clippy, and feature checks