### PR TITLE
fix: open large and public playlists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,6 +2807,7 @@ dependencies = [
  "image",
  "librespot-connect",
  "librespot-core",
+ "librespot-metadata",
  "librespot-playback",
  "log",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ color-thief = "0.2"
 # --- streaming backend (on by default; the single `myx` binary needs it) ---
 librespot-core = { version = "0.8.0", optional = true }
 librespot-connect = { version = "0.8.0", optional = true }
+librespot-metadata = { version = "0.8.0", optional = true, default-features = false }
 librespot-playback = { version = "0.8.0", optional = true, default-features = false, features = ["native-tls", "rodio-backend"] }
 tokio = { version = "1", optional = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 flume = { version = "0.12", optional = true }
@@ -62,6 +63,7 @@ mxc = ["dep:serde", "dep:serde_json"]
 streaming = [
     "dep:librespot-core",
     "dep:librespot-connect",
+    "dep:librespot-metadata",
     "dep:librespot-playback",
     "dep:tokio",
     "dep:flume",

--- a/src/api/detail.rs
+++ b/src/api/detail.rs
@@ -5,15 +5,50 @@ use crate::*;
 
 pub(crate) fn spawn_detail_fetch(
     webapi: Arc<Mutex<WebApi>>,
+    session: librespot_core::Session,
     uri: String,
     name: String,
     tx: flume::Sender<(String, String, Vec<LibItem>)>,
 ) {
-    tokio::task::spawn_blocking(move || {
-        if let Some(token) = token_of(&webapi) {
-            let (title, items) = fetch_detail_blocking(&token, &uri, &name);
-            let _ = tx.send((uri, title, items));
+    tokio::spawn(async move {
+        let web_uri = uri.clone();
+        let web_name = name.clone();
+        let web_result = tokio::task::spawn_blocking(move || {
+            let token = token_of(&webapi)?;
+            Some(fetch_detail_blocking(&token, &web_uri, &web_name))
+        })
+        .await
+        .ok()
+        .flatten();
+        let (title, mut items) = web_result.unwrap_or_else(|| {
+            (
+                name.clone(),
+                vec![LibItem::play(format!("▶︎ Play {name}"), uri.clone())],
+            )
+        });
+
+        // The Web API no longer returns items for public foreign playlists.
+        // Playback still resolves those contexts, so reuse that path here.
+        if uri.starts_with("spotify:playlist:") && !items.iter().any(|item| item.is_track) {
+            match tokio::time::timeout(
+                Duration::from_secs(30),
+                engine::playlist_tracks(&session, &uri),
+            )
+            .await
+            {
+                Ok(Ok(tracks)) => {
+                    items.retain(|item| !item.is_header);
+                    for (order, track) in tracks.into_iter().enumerate() {
+                        let mut item = LibItem::track(track.name, track.artist, track.uri);
+                        item.order = order as u32;
+                        items.push(item);
+                    }
+                }
+                Ok(Err(error)) => liblog(format!("detail: playlist fallback failed: {error:#}")),
+                Err(_) => liblog("detail: playlist fallback timed out"),
+            }
         }
+        let _ = tx.send((uri, title, items));
     });
 }
 
@@ -141,15 +176,17 @@ pub(crate) fn fetch_detail_blocking(token: &str, uri: &str, name: &str) -> (Stri
         }
         "playlist" => {
             // Follow `next` instead of taking only the first page: playlists
-            // routinely exceed the 100-item page size, and the drill-in list
+            // routinely exceed one page, and the drill-in list
             // (plus "play from this track") was silently truncated.
             let before = items.len();
             items.extend(fetch_all_pages(
                 &client,
-                &format!("{API}/playlists/{id}/items?limit=100"),
+                // Spotify reduced this endpoint's maximum from 100 to 50 in
+                // February 2026. A larger limit makes the request fail.
+                &format!("{API}/playlists/{id}/items?limit=50"),
                 token,
                 None, // items[] is top-level on this endpoint
-                10,   // 1,000 tracks, matching the other sections' ceiling
+                20,   // 1,000 tracks, matching the other sections' ceiling
                 parse_playlist_track,
             ));
             if items.len() == before {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -10,6 +10,7 @@
 //! © 2021 Thang Pham), stripped to just what myx needs.
 
 pub mod auth;
+mod playlist;
 
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Duration;
@@ -30,6 +31,7 @@ use librespot_playback::mixer::{Mixer, MixerConfig};
 use librespot_playback::player::{self, Player};
 
 use crate::audio::{VisBands, VisualizationSink};
+pub use playlist::{playlist_tracks, PlaylistTrack};
 
 /// A normalized playback event surfaced to the rest of the app.
 #[derive(Debug, Clone)]

--- a/src/engine/playlist.rs
+++ b/src/engine/playlist.rs
@@ -1,0 +1,104 @@
+//! Playlist catalogue fallback through Spotify's internal context resolver.
+
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use librespot_core::{Session, SpotifyUri};
+use librespot_metadata::{Metadata, Track};
+use tokio::task::JoinSet;
+
+const MAX_TRACKS: usize = 1_000;
+const METADATA_WORKERS: usize = 2;
+const METADATA_TIMEOUT: Duration = Duration::from_secs(6);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlaylistTrack {
+    pub uri: String,
+    pub name: String,
+    pub artist: String,
+}
+
+/// Resolve a playlist and its track labels without the restricted Web API.
+///
+/// The context endpoint gives us the complete, ordered URI list. Track labels
+/// live in a separate metadata endpoint, so those reads run concurrently and
+/// are cached by URI. The small worker count avoids throttling on large lists.
+pub async fn playlist_tracks(session: &Session, context_uri: &str) -> Result<Vec<PlaylistTrack>> {
+    let context = session
+        .spclient()
+        .get_context(context_uri)
+        .await
+        .context("resolve playlist context")?;
+    let uris: Vec<String> = context
+        .pages
+        .iter()
+        .flat_map(|page| page.tracks.iter())
+        .filter_map(|track| track.uri.clone())
+        .filter(|uri| uri.starts_with("spotify:track:"))
+        .take(MAX_TRACKS)
+        .collect();
+    if uris.is_empty() {
+        bail!("playlist context has no tracks");
+    }
+
+    let mut resolved = vec![None; uris.len()];
+    let mut jobs = JoinSet::new();
+    let mut next = 0;
+    while next < uris.len() || !jobs.is_empty() {
+        while next < uris.len() && jobs.len() < METADATA_WORKERS {
+            let index = next;
+            let uri = uris[index].clone();
+            let session = session.clone();
+            jobs.spawn(async move { (index, resolve_track(&session, uri).await) });
+            next += 1;
+        }
+        if let Some(Ok((index, track))) = jobs.join_next().await {
+            resolved[index] = track;
+        }
+    }
+
+    let tracks: Vec<_> = resolved.into_iter().flatten().collect();
+    if tracks.is_empty() {
+        bail!("playlist track metadata unavailable");
+    }
+    Ok(tracks)
+}
+
+async fn resolve_track(session: &Session, uri: String) -> Option<PlaylistTrack> {
+    let cache_key = format!("librespot:track-label:{uri}");
+    if let Some(body) = crate::httpcache::get(&cache_key, None) {
+        if let Ok((name, artist)) = serde_json::from_str::<(String, String)>(&body) {
+            return Some(PlaylistTrack { uri, name, artist });
+        }
+    }
+
+    let spotify_uri = SpotifyUri::from_uri(&uri).ok()?;
+    for attempt in 0..2 {
+        if let Ok(Ok(metadata)) =
+            tokio::time::timeout(METADATA_TIMEOUT, Track::get(session, &spotify_uri)).await
+        {
+            let mut artists: Vec<_> = metadata
+                .artists
+                .iter()
+                .map(|artist| artist.name.as_str())
+                .collect();
+            if artists.is_empty() {
+                artists = metadata
+                    .artists_with_role
+                    .iter()
+                    .map(|artist| artist.name.as_str())
+                    .collect();
+            }
+            let artist = artists.join(", ");
+            let name = metadata.name;
+            if let Ok(body) = serde_json::to_string(&(name.as_str(), artist.as_str())) {
+                crate::httpcache::put(&cache_key, &body);
+            }
+            return Some(PlaylistTrack { uri, name, artist });
+        }
+        if attempt == 0 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+    None
+}

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -78,7 +78,14 @@ pub(crate) fn handle_action_key(
             app.view.actions = None;
         }
         ActionKind::Open { uri, name } => {
-            spawn_detail_fetch(app.svc.webapi.clone(), uri, name, detail_tx.clone());
+            app.status = format!("loading {name}…");
+            spawn_detail_fetch(
+                app.svc.webapi.clone(),
+                app.svc.engine.session(),
+                uri,
+                name,
+                detail_tx.clone(),
+            );
             app.view.actions = None;
         }
         ActionKind::CopyLink { uri } => {

--- a/src/input/key.rs
+++ b/src/input/key.rs
@@ -205,7 +205,14 @@ pub(crate) fn handle_key(
         KeyCode::Enter if mods.contains(KeyModifiers::SHIFT) => play_selected_context(app, false),
         KeyCode::Enter => match app.activate() {
             Activated::Open(uri, name) => {
-                spawn_detail_fetch(app.svc.webapi.clone(), uri, name, chans.detail.clone());
+                app.status = format!("loading {name}…");
+                spawn_detail_fetch(
+                    app.svc.webapi.clone(),
+                    app.svc.engine.session(),
+                    uri,
+                    name,
+                    chans.detail.clone(),
+                );
             }
             Activated::Radio(uri) => {
                 app.status = "starting radio…".to_string();


### PR DESCRIPTION
## What changed

- use Spotify's current maximum of 50 items per playlist page and continue paging up to 1,000 tracks
- fall back to librespot's context resolver when the Web API cannot expose a public third-party playlist
- resolve and cache track labels with bounded concurrency so large playlists do not trigger throttling
- show a loading status while a drill-in is being resolved

## Why

Spotify's February 2026 Web API changes reduced the playlist-items page limit to 50 and restricted playlist contents to playlists owned by or shared with the current user. Myx still requested 100 items and relied solely on that endpoint, so affected playlists appeared as `no tracks — empty or restricted` even though Spotify Connect could play them.

References:

- https://developer.spotify.com/documentation/web-api/reference/get-playlists-items
- https://developer.spotify.com/documentation/web-api/references/changes/february-2026

## Impact

Large owned playlists page correctly, and public third-party playlists can be browsed and played from individual rows again. The fallback is only used when the Web API returns no track rows.

## Validation

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo check --no-default-features --features mxc`
- live cold-cache check against the reported third-party playlist: all 340 tracks resolved in order
